### PR TITLE
Custom fields management and analysis

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,6 +18,7 @@ import 'package:scouting_dashboard_app/pages/picklist/shared_picklist.dart';
 import 'package:scouting_dashboard_app/pages/picklist/picklist_team_breakdown.dart';
 import 'package:scouting_dashboard_app/pages/picklist/picklists.dart';
 import 'package:scouting_dashboard_app/pages/picklist/view_picklist_weights.dart';
+import 'package:scouting_dashboard_app/pages/custom_fields.dart';
 import 'package:scouting_dashboard_app/pages/preview_over.dart';
 import 'package:scouting_dashboard_app/pages/raw_scout_report.dart';
 import 'package:scouting_dashboard_app/pages/scan_qr_codes.dart';
@@ -94,6 +95,7 @@ void main() async {
                 .submitText,
           ),
       '/scouters': (context) => const ScoutersPage(),
+      '/custom_fields': (context) => const CustomFieldsPage(),
       // '/set-api-url': (context) => const SetAPIUrlPage(),
     },
     onGenerateRoute: (settings) {

--- a/lib/pages/custom_fields.dart
+++ b/lib/pages/custom_fields.dart
@@ -79,12 +79,17 @@ class _CustomFieldsPageState extends State<CustomFieldsPage> {
         reorderedFields.map((field) => field.uuid).toList(),
       );
       cachedCustomFields = null;
-    } catch (_) {
+    } catch (e) {
+      // Roll the list back and surface the failure — otherwise a rejected
+      // reorder silently looks like it succeeded.
+      if (!mounted) return;
       setState(() {
         fields = previousFields;
       });
-      scaffoldMessengerState.showSnackBar(const SnackBar(
-        content: Text("Failed to reorder fields"),
+      scaffoldMessengerState.showSnackBar(SnackBar(
+        content: Text(
+          e is LovatAPIException ? e.message : "Failed to reorder fields",
+        ),
         behavior: SnackBarBehavior.floating,
       ));
     }
@@ -133,15 +138,15 @@ class _CustomFieldsPageState extends State<CustomFieldsPage> {
                     key: Key(entry.value.uuid),
                     title: Text(entry.value.name),
                     subtitle: Text(_customFieldSubtitle(entry.value)),
-                    trailing: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        menu(context, entry.value),
-                        ReorderableDragStartListener(
-                          index: entry.key,
-                          child: const Icon(Icons.drag_handle),
-                        ),
-                      ],
+                    onTap: () {
+                      Navigator.of(context).pushWidget(CustomFieldEditorPage(
+                        field: entry.value,
+                        onSaved: fetchData,
+                      ));
+                    },
+                    trailing: ReorderableDragStartListener(
+                      index: entry.key,
+                      child: const Icon(Icons.drag_handle),
                     ),
                   ),
                 )
@@ -182,43 +187,6 @@ class _CustomFieldsPageState extends State<CustomFieldsPage> {
       body: body,
     );
   }
-
-  MenuAnchor menu(BuildContext context, CustomField field) {
-    return MenuAnchor(
-      alignmentOffset: const Offset(-80, 0),
-      menuChildren: [
-        MenuItemButton(
-          leadingIcon: const Icon(Icons.edit_outlined),
-          child: const Text("Edit"),
-          onPressed: () {
-            Navigator.of(context).pushWidget(CustomFieldEditorPage(
-              field: field,
-              onSaved: fetchData,
-            ));
-          },
-        ),
-        MenuItemButton(
-          leadingIcon: const Icon(Icons.archive_outlined),
-          child: const Text("Archive"),
-          onPressed: () {
-            showDialog(
-              context: context,
-              builder: (context) => ArchiveCustomFieldDialog(
-                field: field,
-                onArchived: fetchData,
-              ),
-            );
-          },
-        ),
-      ],
-      builder: (context, controller, child) => IconButton(
-        onPressed: () {
-          controller.isOpen ? controller.close() : controller.open();
-        },
-        icon: const Icon(Icons.more_vert),
-      ),
-    );
-  }
 }
 
 class CustomFieldEditorPage extends StatefulWidget {
@@ -243,14 +211,21 @@ class _CustomFieldEditorPageState extends State<CustomFieldEditorPage> {
 
   CustomFieldType? type;
   bool submitting = false;
+  bool archiving = false;
   String? questionError;
   String? optionsError;
 
   bool get isEditing => widget.field != null;
 
+  bool get isArchived => widget.field?.archived ?? false;
+
   bool get isSelect =>
       type == CustomFieldType.singleSelect ||
       type == CustomFieldType.multiSelect;
+
+  /// Number of options that already existed on the saved field. These can't be
+  /// renamed or removed (only appended to), so their rows are locked.
+  int get lockedOptionCount => widget.field?.options.length ?? 0;
 
   TextEditingController newOptionController([String text = ""]) {
     final controller = TextEditingController(text: text);
@@ -378,14 +353,82 @@ class _CustomFieldEditorPageState extends State<CustomFieldEditorPage> {
     }
   }
 
+  Future<void> archive() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => const _ArchiveConfirmationDialog(),
+    );
+
+    if (confirmed != true || !mounted) return;
+
+    setState(() {
+      archiving = true;
+    });
+
+    final navigatorState = Navigator.of(context);
+    final scaffoldMessengerState = ScaffoldMessenger.of(context);
+
+    try {
+      await lovatAPI.archiveCustomField(widget.field!.uuid);
+      cachedCustomFields = null;
+      widget.onSaved?.call();
+      scaffoldMessengerState.showSnackBar(const SnackBar(
+        content: Text("Archived custom field"),
+        behavior: SnackBarBehavior.floating,
+      ));
+      navigatorState.pop();
+    } on LovatAPIException catch (e) {
+      _showActionError("Failed to archive field: ${e.message}");
+    } catch (_) {
+      _showActionError("Failed to archive field");
+    }
+  }
+
+  Future<void> unarchive() async {
+    setState(() {
+      archiving = true;
+    });
+
+    final navigatorState = Navigator.of(context);
+    final scaffoldMessengerState = ScaffoldMessenger.of(context);
+
+    try {
+      await lovatAPI.unarchiveCustomField(widget.field!.uuid);
+      cachedCustomFields = null;
+      widget.onSaved?.call();
+      scaffoldMessengerState.showSnackBar(const SnackBar(
+        content: Text("Unarchived custom field"),
+        behavior: SnackBarBehavior.floating,
+      ));
+      navigatorState.pop();
+    } on LovatAPIException catch (e) {
+      _showActionError("Failed to unarchive field: ${e.message}");
+    } catch (_) {
+      _showActionError("Failed to unarchive field");
+    }
+  }
+
+  void _showActionError(String message) {
+    if (!mounted) return;
+    setState(() {
+      archiving = false;
+    });
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+      content: Text(message),
+      behavior: SnackBarBehavior.floating,
+    ));
+  }
+
   @override
   Widget build(BuildContext context) {
+    final busy = submitting || archiving;
+
     return Scaffold(
       appBar: AppBar(
         title: Text(isEditing ? "Edit Custom Field" : "New Custom Field"),
         actions: [
           IconButton(
-            onPressed: submitting || type == null ? null : save,
+            onPressed: busy || type == null ? null : save,
             icon: const Icon(Icons.check),
             tooltip: isEditing ? "Save changes" : "Create",
             color: Colors.green,
@@ -393,7 +436,7 @@ class _CustomFieldEditorPageState extends State<CustomFieldEditorPage> {
         ],
         bottom: PreferredSize(
           preferredSize: const Size.fromHeight(4),
-          child: submitting
+          child: busy
               ? const LinearProgressIndicator()
               : const SizedBox(height: 4),
         ),
@@ -444,33 +487,43 @@ class _CustomFieldEditorPageState extends State<CustomFieldEditorPage> {
             ),
             const SizedBox(height: 8),
             ...optionControllers.asMap().entries.map(
-                  (entry) => Padding(
-                    padding: const EdgeInsets.only(bottom: 8),
-                    child: Row(
-                      children: [
-                        Expanded(
-                          child: TextField(
-                            controller: entry.value,
-                            decoration: InputDecoration(
-                              filled: true,
-                              labelText: "Option ${entry.key + 1}",
-                            ),
-                            textCapitalization: TextCapitalization.sentences,
+              (entry) {
+                // Options that were already saved can't be renamed or removed
+                // (only reordered/appended to), so lock their row.
+                final locked = entry.key < lockedOptionCount;
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: 8),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: TextField(
+                          controller: entry.value,
+                          enabled: !locked,
+                          decoration: InputDecoration(
+                            filled: true,
+                            labelText: "Option ${entry.key + 1}",
                           ),
+                          textCapitalization: TextCapitalization.sentences,
                         ),
-                        IconButton(
-                          onPressed: () {
-                            setState(() {
-                              optionControllers.removeAt(entry.key);
-                            });
-                          },
-                          icon: const Icon(Icons.remove_circle_outline),
-                          tooltip: "Remove option",
-                        ),
-                      ],
-                    ),
+                      ),
+                      IconButton(
+                        onPressed: locked
+                            ? null
+                            : () {
+                                setState(() {
+                                  optionControllers.removeAt(entry.key);
+                                });
+                              },
+                        icon: const Icon(Icons.remove_circle_outline),
+                        tooltip: locked
+                            ? "Existing options can't be removed"
+                            : "Remove option",
+                      ),
+                    ],
                   ),
-                ),
+                );
+              },
+            ),
             if (optionsError != null) ...[
               const SizedBox(height: 2),
               Text(
@@ -494,29 +547,32 @@ class _CustomFieldEditorPageState extends State<CustomFieldEditorPage> {
               ),
             ),
           ],
+          if (isEditing) ...[
+            const SizedBox(height: 32),
+            SizedBox(
+              width: double.infinity,
+              child: isArchived
+                  ? FilledButton.tonalIcon(
+                      onPressed: busy ? null : unarchive,
+                      icon: const Icon(Icons.unarchive_outlined),
+                      label: const Text("Unarchive field"),
+                    )
+                  : FilledButton.tonalIcon(
+                      onPressed: busy ? null : archive,
+                      icon: const Icon(Icons.archive_outlined),
+                      label: const Text("Archive field"),
+                    ),
+            ),
+          ],
         ],
       ),
     );
   }
 }
 
-class ArchiveCustomFieldDialog extends StatefulWidget {
-  const ArchiveCustomFieldDialog({
-    super.key,
-    required this.field,
-    this.onArchived,
-  });
-
-  final CustomField field;
-  final Function()? onArchived;
-
-  @override
-  State<ArchiveCustomFieldDialog> createState() =>
-      _ArchiveCustomFieldDialogState();
-}
-
-class _ArchiveCustomFieldDialogState extends State<ArchiveCustomFieldDialog> {
-  bool submitting = false;
+/// Confirmation dialog for archiving; pops with `true` when confirmed.
+class _ArchiveConfirmationDialog extends StatelessWidget {
+  const _ArchiveConfirmationDialog();
 
   @override
   Widget build(BuildContext context) {
@@ -526,57 +582,12 @@ class _ArchiveCustomFieldDialogState extends State<ArchiveCustomFieldDialog> {
           "Scouts will stop seeing this question in Lovat Collection. Answers already collected stay in your data, and you can unarchive it later."),
       actions: [
         TextButton(
-          onPressed: submitting
-              ? null
-              : () {
-                  Navigator.of(context).pop();
-                },
+          onPressed: () => Navigator.of(context).pop(false),
           child: const Text("Cancel"),
         ),
         FilledButton(
-          onPressed: submitting
-              ? null
-              : () async {
-                  setState(() {
-                    submitting = true;
-                  });
-
-                  final navigatorState = Navigator.of(context);
-                  final scaffoldMessengerState = ScaffoldMessenger.of(context);
-
-                  try {
-                    await lovatAPI.archiveCustomField(widget.field.uuid);
-                    cachedCustomFields = null;
-                    widget.onArchived?.call();
-                    navigatorState.pop();
-                  } on LovatAPIException catch (e) {
-                    scaffoldMessengerState.showSnackBar(SnackBar(
-                      content: Text("Failed to archive field: ${e.message}"),
-                      behavior: SnackBarBehavior.floating,
-                    ));
-                    setState(() {
-                      submitting = false;
-                    });
-                  } catch (_) {
-                    scaffoldMessengerState.showSnackBar(const SnackBar(
-                      content: Text("Failed to archive field"),
-                      behavior: SnackBarBehavior.floating,
-                    ));
-                    setState(() {
-                      submitting = false;
-                    });
-                  }
-                },
-          child: submitting
-              ? const SizedBox(
-                  height: 16,
-                  width: 16,
-                  child: CircularProgressIndicator(
-                    valueColor: AlwaysStoppedAnimation(Colors.white),
-                    strokeWidth: 2,
-                  ),
-                )
-              : const Text("Archive"),
+          onPressed: () => Navigator.of(context).pop(true),
+          child: const Text("Archive"),
         ),
       ],
     );
@@ -629,27 +640,6 @@ class _ArchivedCustomFieldsPageState extends State<ArchivedCustomFieldsPage> {
     fetchData();
   }
 
-  Future<void> unarchive(CustomField field) async {
-    final scaffoldMessengerState = ScaffoldMessenger.of(context);
-
-    try {
-      await lovatAPI.unarchiveCustomField(field.uuid);
-      cachedCustomFields = null;
-      widget.onChanged?.call();
-      fetchData();
-    } on LovatAPIException catch (e) {
-      scaffoldMessengerState.showSnackBar(SnackBar(
-        content: Text("Failed to unarchive field: ${e.message}"),
-        behavior: SnackBarBehavior.floating,
-      ));
-    } catch (_) {
-      scaffoldMessengerState.showSnackBar(const SnackBar(
-        content: Text("Failed to unarchive field"),
-        behavior: SnackBarBehavior.floating,
-      ));
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
     Widget body = SkeletonListView(
@@ -680,7 +670,15 @@ class _ArchivedCustomFieldsPageState extends State<ArchivedCustomFieldsPage> {
                 (field) => ListTile(
                   title: Text(field.name),
                   subtitle: Text(_customFieldSubtitle(field)),
-                  trailing: menu(context, field),
+                  onTap: () {
+                    Navigator.of(context).pushWidget(CustomFieldEditorPage(
+                      field: field,
+                      onSaved: () {
+                        fetchData();
+                        widget.onChanged?.call();
+                      },
+                    ));
+                  },
                 ),
               )
               .toList(),
@@ -697,25 +695,6 @@ class _ArchivedCustomFieldsPageState extends State<ArchivedCustomFieldsPage> {
         title: const Text("Archived Custom Fields"),
       ),
       body: body,
-    );
-  }
-
-  MenuAnchor menu(BuildContext context, CustomField field) {
-    return MenuAnchor(
-      alignmentOffset: const Offset(-80, 0),
-      menuChildren: [
-        MenuItemButton(
-          leadingIcon: const Icon(Icons.unarchive_outlined),
-          child: const Text("Unarchive"),
-          onPressed: () => unarchive(field),
-        ),
-      ],
-      builder: (context, controller, child) => IconButton(
-        onPressed: () {
-          controller.isOpen ? controller.close() : controller.open();
-        },
-        icon: const Icon(Icons.more_vert),
-      ),
     );
   }
 }

--- a/lib/pages/custom_fields.dart
+++ b/lib/pages/custom_fields.dart
@@ -8,6 +8,9 @@ import 'package:scouting_dashboard_app/reusable/page_body.dart';
 import 'package:scouting_dashboard_app/reusable/push_widget_extension.dart';
 import 'package:scouting_dashboard_app/reusable/scrollable_page_body.dart';
 import 'package:skeletons_forked/skeletons_forked.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+const _customFieldsGuideUrl = "https://learn.lovat.app/guides/custom-fields";
 
 String _customFieldSubtitle(CustomField field) {
   if (field.type == CustomFieldType.singleSelect ||
@@ -119,7 +122,15 @@ class _CustomFieldsPageState extends State<CustomFieldsPage> {
                 "Tap + to ask your scouts extra questions after each match.",
                 style: Theme.of(context).textTheme.bodyMedium,
                 textAlign: TextAlign.center,
-              )
+              ),
+              const SizedBox(height: 8),
+              TextButton(
+                onPressed: () => launchUrl(
+                  Uri.parse(_customFieldsGuideUrl),
+                  mode: LaunchMode.externalApplication,
+                ),
+                child: const Text("Learn more"),
+              ),
             ],
           ),
         );

--- a/lib/pages/custom_fields.dart
+++ b/lib/pages/custom_fields.dart
@@ -1,0 +1,721 @@
+import 'package:flutter/material.dart';
+import 'package:scouting_dashboard_app/reusable/friendly_error_view.dart';
+import 'package:scouting_dashboard_app/reusable/inset_picker.dart';
+import 'package:scouting_dashboard_app/reusable/lovat_api/custom_fields.dart';
+import 'package:scouting_dashboard_app/reusable/lovat_api/lovat_api.dart';
+import 'package:scouting_dashboard_app/reusable/navigation_drawer.dart';
+import 'package:scouting_dashboard_app/reusable/page_body.dart';
+import 'package:scouting_dashboard_app/reusable/push_widget_extension.dart';
+import 'package:scouting_dashboard_app/reusable/scrollable_page_body.dart';
+import 'package:skeletons_forked/skeletons_forked.dart';
+
+String _customFieldSubtitle(CustomField field) {
+  if (field.type == CustomFieldType.singleSelect ||
+      field.type == CustomFieldType.multiSelect) {
+    return "${field.type.localizedDescription} · ${field.options.length} option${field.options.length == 1 ? '' : 's'}";
+  }
+
+  return field.type.localizedDescription;
+}
+
+class CustomFieldsPage extends StatefulWidget {
+  const CustomFieldsPage({super.key});
+
+  @override
+  State<CustomFieldsPage> createState() => _CustomFieldsPageState();
+}
+
+class _CustomFieldsPageState extends State<CustomFieldsPage> {
+  List<CustomField>? fields;
+  String? error;
+
+  Future<void> fetchData() async {
+    try {
+      setState(() {
+        fields = null;
+        error = null;
+      });
+
+      final data = await getCustomFieldDefinitions(force: true);
+
+      setState(() {
+        fields = data.where((field) => !field.archived).toList();
+      });
+    } on LovatAPIException catch (e) {
+      setState(() {
+        error = e.message;
+      });
+    } catch (_) {
+      setState(() {
+        error = "Failed to load custom fields";
+      });
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    fetchData();
+  }
+
+  Future<void> reorder(int oldIndex, int newIndex) async {
+    final scaffoldMessengerState = ScaffoldMessenger.of(context);
+
+    if (oldIndex < newIndex) {
+      newIndex -= 1;
+    }
+
+    final previousFields = fields!.toList();
+    final reorderedFields = fields!.toList();
+    final field = reorderedFields.removeAt(oldIndex);
+    reorderedFields.insert(newIndex, field);
+
+    setState(() {
+      fields = reorderedFields;
+    });
+
+    try {
+      await lovatAPI.reorderCustomFields(
+        reorderedFields.map((field) => field.uuid).toList(),
+      );
+      cachedCustomFields = null;
+    } catch (_) {
+      setState(() {
+        fields = previousFields;
+      });
+      scaffoldMessengerState.showSnackBar(const SnackBar(
+        content: Text("Failed to reorder fields"),
+        behavior: SnackBarBehavior.floating,
+      ));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    Widget body = SkeletonListView(
+      itemBuilder: (context, index) => SkeletonListTile(),
+    );
+
+    if (fields != null) {
+      if (fields!.isEmpty) {
+        body = PageBody(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Image.asset("assets/images/no-notes-dark.png", width: 250),
+              const SizedBox(height: 8),
+              Text(
+                "No custom fields",
+                style: Theme.of(context).textTheme.headlineMedium,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 2),
+              Text(
+                "Tap + to ask your scouts extra questions after each match.",
+                style: Theme.of(context).textTheme.bodyMedium,
+                textAlign: TextAlign.center,
+              )
+            ],
+          ),
+        );
+      } else {
+        body = PageBody(
+          padding: EdgeInsets.zero,
+          bottom: false,
+          child: ReorderableListView(
+            buildDefaultDragHandles: false,
+            onReorder: reorder,
+            children: fields!
+                .asMap()
+                .entries
+                .map(
+                  (entry) => ListTile(
+                    key: Key(entry.value.uuid),
+                    title: Text(entry.value.name),
+                    subtitle: Text(_customFieldSubtitle(entry.value)),
+                    trailing: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        menu(context, entry.value),
+                        ReorderableDragStartListener(
+                          index: entry.key,
+                          child: const Icon(Icons.drag_handle),
+                        ),
+                      ],
+                    ),
+                  ),
+                )
+                .toList(),
+          ),
+        );
+      }
+    }
+
+    if (error != null) {
+      body = FriendlyErrorView(errorMessage: error, onRetry: fetchData);
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text("Custom Fields"),
+        actions: [
+          IconButton(
+            onPressed: () {
+              Navigator.of(context).pushWidget(ArchivedCustomFieldsPage(
+                onChanged: fetchData,
+              ));
+            },
+            icon: const Icon(Icons.access_time),
+            tooltip: "View archived fields",
+          ),
+        ],
+      ),
+      drawer: const GlobalNavigationDrawer(),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          Navigator.of(context).pushWidget(CustomFieldEditorPage(
+            onSaved: fetchData,
+          ));
+        },
+        child: const Icon(Icons.add),
+      ),
+      body: body,
+    );
+  }
+
+  MenuAnchor menu(BuildContext context, CustomField field) {
+    return MenuAnchor(
+      alignmentOffset: const Offset(-80, 0),
+      menuChildren: [
+        MenuItemButton(
+          leadingIcon: const Icon(Icons.edit_outlined),
+          child: const Text("Edit"),
+          onPressed: () {
+            Navigator.of(context).pushWidget(CustomFieldEditorPage(
+              field: field,
+              onSaved: fetchData,
+            ));
+          },
+        ),
+        MenuItemButton(
+          leadingIcon: const Icon(Icons.archive_outlined),
+          child: const Text("Archive"),
+          onPressed: () {
+            showDialog(
+              context: context,
+              builder: (context) => ArchiveCustomFieldDialog(
+                field: field,
+                onArchived: fetchData,
+              ),
+            );
+          },
+        ),
+      ],
+      builder: (context, controller, child) => IconButton(
+        onPressed: () {
+          controller.isOpen ? controller.close() : controller.open();
+        },
+        icon: const Icon(Icons.more_vert),
+      ),
+    );
+  }
+}
+
+class CustomFieldEditorPage extends StatefulWidget {
+  const CustomFieldEditorPage({
+    super.key,
+    this.field,
+    this.onSaved,
+  });
+
+  /// The field to edit, or null to create a new one.
+  final CustomField? field;
+  final Function()? onSaved;
+
+  @override
+  State<CustomFieldEditorPage> createState() => _CustomFieldEditorPageState();
+}
+
+class _CustomFieldEditorPageState extends State<CustomFieldEditorPage> {
+  late final TextEditingController questionController;
+  final List<TextEditingController> optionControllers = [];
+  final List<TextEditingController> spawnedControllers = [];
+
+  CustomFieldType? type;
+  bool submitting = false;
+  String? questionError;
+  String? optionsError;
+
+  bool get isEditing => widget.field != null;
+
+  bool get isSelect =>
+      type == CustomFieldType.singleSelect ||
+      type == CustomFieldType.multiSelect;
+
+  TextEditingController newOptionController([String text = ""]) {
+    final controller = TextEditingController(text: text);
+    spawnedControllers.add(controller);
+    return controller;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+
+    questionController = TextEditingController(text: widget.field?.name ?? "");
+    type = widget.field?.type;
+
+    for (final option in widget.field?.options ?? <String>[]) {
+      optionControllers.add(newOptionController(option));
+    }
+  }
+
+  @override
+  void dispose() {
+    questionController.dispose();
+    for (final controller in spawnedControllers) {
+      controller.dispose();
+    }
+    super.dispose();
+  }
+
+  void ensureMinimumOptionRows() {
+    while (optionControllers.length < 2) {
+      optionControllers.add(newOptionController());
+    }
+  }
+
+  String typeDescription(CustomFieldType type) {
+    switch (type) {
+      case CustomFieldType.text:
+        return "Scouts type a free-form answer";
+      case CustomFieldType.number:
+        return "Scouts enter a number, averaged in analysis";
+      case CustomFieldType.singleSelect:
+        return "Scouts pick one option";
+      case CustomFieldType.multiSelect:
+        return "Scouts pick any number of options";
+    }
+  }
+
+  Future<void> save() async {
+    final name = questionController.text.trim();
+    final options = optionControllers
+        .map((controller) => controller.text.trim())
+        .where((option) => option.isNotEmpty)
+        .toList();
+
+    String? questionError;
+    String? optionsError;
+
+    if (name.isEmpty) {
+      questionError = "Enter a question";
+    }
+
+    if (isSelect) {
+      if (options.length < 2) {
+        optionsError = "Add at least 2 options";
+      } else if (options.toSet().length != options.length) {
+        optionsError = "Options must be unique";
+      }
+    }
+
+    setState(() {
+      this.questionError = questionError;
+      this.optionsError = optionsError;
+    });
+
+    if (questionError != null || optionsError != null) return;
+
+    setState(() {
+      submitting = true;
+    });
+
+    final navigatorState = Navigator.of(context);
+    final scaffoldMessengerState = ScaffoldMessenger.of(context);
+
+    try {
+      if (isEditing) {
+        await lovatAPI.updateCustomField(
+          widget.field!.uuid,
+          name: name,
+          options: isSelect ? options : null,
+        );
+      } else {
+        await lovatAPI.createCustomField(
+          name: name,
+          type: type!,
+          options: isSelect ? options : const [],
+        );
+      }
+
+      cachedCustomFields = null;
+      widget.onSaved?.call();
+
+      scaffoldMessengerState.showSnackBar(SnackBar(
+        content:
+            Text(isEditing ? "Saved custom field" : "Created custom field"),
+        behavior: SnackBarBehavior.floating,
+      ));
+
+      navigatorState.pop();
+    } on LovatAPIException catch (e) {
+      scaffoldMessengerState.showSnackBar(SnackBar(
+        content: Text(e.message),
+        behavior: SnackBarBehavior.floating,
+      ));
+    } catch (_) {
+      scaffoldMessengerState.showSnackBar(const SnackBar(
+        content: Text("Failed to save custom field"),
+        behavior: SnackBarBehavior.floating,
+      ));
+    } finally {
+      if (mounted) {
+        setState(() {
+          submitting = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(isEditing ? "Edit Custom Field" : "New Custom Field"),
+        actions: [
+          IconButton(
+            onPressed: submitting || type == null ? null : save,
+            icon: const Icon(Icons.check),
+            tooltip: isEditing ? "Save changes" : "Create",
+            color: Colors.green,
+          ),
+        ],
+        bottom: PreferredSize(
+          preferredSize: const Size.fromHeight(4),
+          child: submitting
+              ? const LinearProgressIndicator()
+              : const SizedBox(height: 4),
+        ),
+      ),
+      body: ScrollablePageBody(
+        children: [
+          TextField(
+            controller: questionController,
+            decoration: InputDecoration(
+              filled: true,
+              labelText: "Question",
+              errorText: questionError,
+            ),
+            textCapitalization: TextCapitalization.sentences,
+          ),
+          const SizedBox(height: 24),
+          Text(
+            "Type",
+            style: Theme.of(context).textTheme.labelLarge,
+          ),
+          const SizedBox(height: 8),
+          InsetPicker(
+            CustomFieldType.values,
+            titleBuilder: (type) => type.localizedDescription,
+            descriptionBuilder: typeDescription,
+            selectedItem: type,
+            onChanged: isEditing
+                ? null
+                : (CustomFieldType? value) => setState(() {
+                      type = value;
+                      if (isSelect) ensureMinimumOptionRows();
+                    }),
+          ),
+          if (isEditing) ...[
+            const SizedBox(height: 8),
+            Text(
+              "Type can't be changed after a field is created. Archive this field and create a new one instead.",
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+            ),
+          ],
+          if (isSelect) ...[
+            const SizedBox(height: 24),
+            Text(
+              "Options",
+              style: Theme.of(context).textTheme.labelLarge,
+            ),
+            const SizedBox(height: 8),
+            ...optionControllers.asMap().entries.map(
+                  (entry) => Padding(
+                    padding: const EdgeInsets.only(bottom: 8),
+                    child: Row(
+                      children: [
+                        Expanded(
+                          child: TextField(
+                            controller: entry.value,
+                            decoration: InputDecoration(
+                              filled: true,
+                              labelText: "Option ${entry.key + 1}",
+                            ),
+                            textCapitalization: TextCapitalization.sentences,
+                          ),
+                        ),
+                        IconButton(
+                          onPressed: () {
+                            setState(() {
+                              optionControllers.removeAt(entry.key);
+                            });
+                          },
+                          icon: const Icon(Icons.remove_circle_outline),
+                          tooltip: "Remove option",
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+            if (optionsError != null) ...[
+              const SizedBox(height: 2),
+              Text(
+                optionsError!,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: Theme.of(context).colorScheme.error,
+                    ),
+              ),
+              const SizedBox(height: 2),
+            ],
+            Align(
+              alignment: Alignment.centerLeft,
+              child: TextButton.icon(
+                onPressed: () {
+                  setState(() {
+                    optionControllers.add(newOptionController());
+                  });
+                },
+                icon: const Icon(Icons.add),
+                label: const Text("Add option"),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class ArchiveCustomFieldDialog extends StatefulWidget {
+  const ArchiveCustomFieldDialog({
+    super.key,
+    required this.field,
+    this.onArchived,
+  });
+
+  final CustomField field;
+  final Function()? onArchived;
+
+  @override
+  State<ArchiveCustomFieldDialog> createState() =>
+      _ArchiveCustomFieldDialogState();
+}
+
+class _ArchiveCustomFieldDialogState extends State<ArchiveCustomFieldDialog> {
+  bool submitting = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text("Archive field?"),
+      content: const Text(
+          "Scouts will stop seeing this question in Lovat Collection. Answers already collected stay in your data, and you can unarchive it later."),
+      actions: [
+        TextButton(
+          onPressed: submitting
+              ? null
+              : () {
+                  Navigator.of(context).pop();
+                },
+          child: const Text("Cancel"),
+        ),
+        FilledButton(
+          onPressed: submitting
+              ? null
+              : () async {
+                  setState(() {
+                    submitting = true;
+                  });
+
+                  final navigatorState = Navigator.of(context);
+                  final scaffoldMessengerState = ScaffoldMessenger.of(context);
+
+                  try {
+                    await lovatAPI.archiveCustomField(widget.field.uuid);
+                    cachedCustomFields = null;
+                    widget.onArchived?.call();
+                    navigatorState.pop();
+                  } on LovatAPIException catch (e) {
+                    scaffoldMessengerState.showSnackBar(SnackBar(
+                      content: Text("Failed to archive field: ${e.message}"),
+                      behavior: SnackBarBehavior.floating,
+                    ));
+                    setState(() {
+                      submitting = false;
+                    });
+                  } catch (_) {
+                    scaffoldMessengerState.showSnackBar(const SnackBar(
+                      content: Text("Failed to archive field"),
+                      behavior: SnackBarBehavior.floating,
+                    ));
+                    setState(() {
+                      submitting = false;
+                    });
+                  }
+                },
+          child: submitting
+              ? const SizedBox(
+                  height: 16,
+                  width: 16,
+                  child: CircularProgressIndicator(
+                    valueColor: AlwaysStoppedAnimation(Colors.white),
+                    strokeWidth: 2,
+                  ),
+                )
+              : const Text("Archive"),
+        ),
+      ],
+    );
+  }
+}
+
+class ArchivedCustomFieldsPage extends StatefulWidget {
+  const ArchivedCustomFieldsPage({
+    super.key,
+    this.onChanged,
+  });
+
+  final Function()? onChanged;
+
+  @override
+  State<ArchivedCustomFieldsPage> createState() =>
+      _ArchivedCustomFieldsPageState();
+}
+
+class _ArchivedCustomFieldsPageState extends State<ArchivedCustomFieldsPage> {
+  List<CustomField>? fields;
+  String? error;
+
+  Future<void> fetchData() async {
+    try {
+      setState(() {
+        fields = null;
+        error = null;
+      });
+
+      final data = await getCustomFieldDefinitions(force: true);
+
+      setState(() {
+        fields = data.where((field) => field.archived).toList();
+      });
+    } on LovatAPIException catch (e) {
+      setState(() {
+        error = e.message;
+      });
+    } catch (_) {
+      setState(() {
+        error = "Failed to load custom fields";
+      });
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    fetchData();
+  }
+
+  Future<void> unarchive(CustomField field) async {
+    final scaffoldMessengerState = ScaffoldMessenger.of(context);
+
+    try {
+      await lovatAPI.unarchiveCustomField(field.uuid);
+      cachedCustomFields = null;
+      widget.onChanged?.call();
+      fetchData();
+    } on LovatAPIException catch (e) {
+      scaffoldMessengerState.showSnackBar(SnackBar(
+        content: Text("Failed to unarchive field: ${e.message}"),
+        behavior: SnackBarBehavior.floating,
+      ));
+    } catch (_) {
+      scaffoldMessengerState.showSnackBar(const SnackBar(
+        content: Text("Failed to unarchive field"),
+        behavior: SnackBarBehavior.floating,
+      ));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    Widget body = SkeletonListView(
+      itemBuilder: (context, index) => SkeletonListTile(),
+    );
+
+    if (fields != null) {
+      if (fields!.isEmpty) {
+        body = PageBody(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Image.asset("assets/images/no-notes-dark.png", width: 250),
+              const SizedBox(height: 8),
+              Text(
+                "No archived fields",
+                style: Theme.of(context).textTheme.headlineMedium,
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
+        );
+      } else {
+        body = ScrollablePageBody(
+          padding: EdgeInsets.zero,
+          children: fields!
+              .map(
+                (field) => ListTile(
+                  title: Text(field.name),
+                  subtitle: Text(_customFieldSubtitle(field)),
+                  trailing: menu(context, field),
+                ),
+              )
+              .toList(),
+        );
+      }
+    }
+
+    if (error != null) {
+      body = FriendlyErrorView(errorMessage: error, onRetry: fetchData);
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text("Archived Custom Fields"),
+      ),
+      body: body,
+    );
+  }
+
+  MenuAnchor menu(BuildContext context, CustomField field) {
+    return MenuAnchor(
+      alignmentOffset: const Offset(-80, 0),
+      menuChildren: [
+        MenuItemButton(
+          leadingIcon: const Icon(Icons.unarchive_outlined),
+          child: const Text("Unarchive"),
+          onPressed: () => unarchive(field),
+        ),
+      ],
+      builder: (context, controller, child) => IconButton(
+        onPressed: () {
+          controller.isOpen ? controller.close() : controller.open();
+        },
+        icon: const Icon(Icons.more_vert),
+      ),
+    );
+  }
+}

--- a/lib/pages/picklist/edit_picklist.dart
+++ b/lib/pages/picklist/edit_picklist.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:scouting_dashboard_app/pages/picklist/picklist_models.dart';
+import 'package:scouting_dashboard_app/reusable/custom_field_indicator.dart';
 import 'package:scouting_dashboard_app/reusable/scrollable_page_body.dart';
 
 class EditPicklistPage extends StatefulWidget {
@@ -14,6 +15,23 @@ class _EditPicklistPageState extends State<EditPicklistPage> {
   TextEditingController titleFieldController = TextEditingController();
   bool initialized = false;
 
+  /// Appends any available weight (archived custom fields included, so
+  /// existing weights on them can still be zeroed) that the picklist doesn't
+  /// have yet, at value 0.
+  Future<void> mergeMissingWeights(ConfiguredPicklist picklist) async {
+    final allWeights = await getAllPicklistWeights();
+
+    if (!mounted) return;
+
+    setState(() {
+      for (final weight in allWeights) {
+        if (!picklist.weights.any((e) => e.path == weight.path)) {
+          picklist.weights.add(weight);
+        }
+      }
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     ConfiguredPicklist picklist = (ModalRoute.of(context)!.settings.arguments
@@ -23,7 +41,10 @@ class _EditPicklistPageState extends State<EditPicklistPage> {
         .settings
         .arguments as Map<String, dynamic>)['onChanged'];
 
-    if (!initialized) titleFieldController.text = picklist.title;
+    if (!initialized) {
+      titleFieldController.text = picklist.title;
+      mergeMissingWeights(picklist);
+    }
 
     initialized = true;
 
@@ -66,7 +87,21 @@ class _EditPicklistPageState extends State<EditPicklistPage> {
                     children: [
                       Padding(
                         padding: const EdgeInsets.fromLTRB(24, 0, 24, 15),
-                        child: Text(weight.localizedName),
+                        child: Row(
+                          children: [
+                            Flexible(
+                              child: Text(
+                                weight.localizedName,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                            if (weight.isCustom ||
+                                weight.path.startsWith('cf_')) ...[
+                              const SizedBox(width: 8),
+                              const CustomFieldIndicator(),
+                            ],
+                          ],
+                        ),
                       ),
                       Slider(
                           min: 0,

--- a/lib/pages/picklist/new_picklist.dart
+++ b/lib/pages/picklist/new_picklist.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:scouting_dashboard_app/constants.dart';
 import 'package:scouting_dashboard_app/pages/picklist/picklist_models.dart';
+import 'package:scouting_dashboard_app/reusable/custom_field_indicator.dart';
 import 'package:scouting_dashboard_app/reusable/scrollable_page_body.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -13,10 +13,28 @@ class NewPicklistPage extends StatefulWidget {
 }
 
 class _NewPicklistPageState extends State<NewPicklistPage> {
-  ConfiguredPicklist picklist = ConfiguredPicklist.defaultWeights("");
+  ConfiguredPicklist? picklist;
+
+  @override
+  void initState() {
+    super.initState();
+    loadWeights();
+  }
+
+  Future<void> loadWeights() async {
+    final weights = await getAllPicklistWeights(includeArchived: false);
+
+    if (!mounted) return;
+
+    setState(() {
+      picklist = ConfiguredPicklist.autoUuid("", weights);
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
+    final picklist = this.picklist;
+
     return Scaffold(
       appBar: AppBar(
         title: const Text("New Picklist"),
@@ -24,12 +42,14 @@ class _NewPicklistPageState extends State<NewPicklistPage> {
           FutureBuilder<SharedPreferences>(
               future: SharedPreferences.getInstance(),
               builder: (context, snapshot) {
-                if (snapshot.connectionState == ConnectionState.done) {
+                if (snapshot.connectionState == ConnectionState.done &&
+                    picklist != null) {
                   picklist.author = snapshot.data!.getString('username');
                 }
 
                 return IconButton(
-                  onPressed: picklist.title.isEmpty ||
+                  onPressed: picklist == null ||
+                          picklist.title.isEmpty ||
                           snapshot.connectionState != ConnectionState.done
                       ? null
                       : () async {
@@ -59,51 +79,63 @@ class _NewPicklistPageState extends State<NewPicklistPage> {
               })
         ],
       ),
-      body: ScrollablePageBody(padding: EdgeInsets.zero, children: [
-        Padding(
-          padding: const EdgeInsets.fromLTRB(24, 16, 24, 26),
-          child: TextField(
-            decoration: const InputDecoration(
-              filled: true,
-              label: Text("Title"),
-            ),
-            textCapitalization: TextCapitalization.words,
-            onChanged: (value) => setState(() {
-              picklist.title = value;
-            }),
-          ),
-        ),
-        Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: picklistWeights
-              .map((weight) => Column(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: [
-                      Padding(
-                        padding: const EdgeInsets.fromLTRB(24, 0, 24, 15),
-                        child: Text(weight.localizedName),
-                      ),
-                      Slider(
-                          min: 0,
-                          max: 1,
-                          divisions: 8,
-                          value: picklist.weights
-                              .firstWhere((e) => e.path == weight.path)
-                              .value,
-                          onChanged: (value) {
-                            HapticFeedback.selectionClick();
-                            setState(() {
-                              picklist.weights
-                                  .firstWhere((e) => e.path == weight.path)
-                                  .value = value;
-                            });
-                          }),
-                      const SizedBox(height: 14),
-                    ],
-                  ))
-              .toList(),
-        )
-      ]),
+      body: picklist == null
+          ? const LinearProgressIndicator()
+          : ScrollablePageBody(padding: EdgeInsets.zero, children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(24, 16, 24, 26),
+                child: TextField(
+                  decoration: const InputDecoration(
+                    filled: true,
+                    label: Text("Title"),
+                  ),
+                  textCapitalization: TextCapitalization.words,
+                  onChanged: (value) => setState(() {
+                    picklist.title = value;
+                  }),
+                ),
+              ),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: picklist.weights
+                    .map((weight) => Column(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            Padding(
+                              padding: const EdgeInsets.fromLTRB(24, 0, 24, 15),
+                              child: Row(
+                                children: [
+                                  Flexible(
+                                    child: Text(
+                                      weight.localizedName,
+                                      overflow: TextOverflow.ellipsis,
+                                    ),
+                                  ),
+                                  if (weight.isCustom ||
+                                      weight.path.startsWith('cf_')) ...[
+                                    const SizedBox(width: 8),
+                                    const CustomFieldIndicator(),
+                                  ],
+                                ],
+                              ),
+                            ),
+                            Slider(
+                                min: 0,
+                                max: 1,
+                                divisions: 8,
+                                value: weight.value,
+                                onChanged: (value) {
+                                  HapticFeedback.selectionClick();
+                                  setState(() {
+                                    weight.value = value;
+                                  });
+                                }),
+                            const SizedBox(height: 14),
+                          ],
+                        ))
+                    .toList(),
+              )
+            ]),
     );
   }
 }

--- a/lib/pages/picklist/picklist_models.dart
+++ b/lib/pages/picklist/picklist_models.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:scouting_dashboard_app/constants.dart';
+import 'package:scouting_dashboard_app/reusable/lovat_api/custom_fields.dart';
 import 'package:scouting_dashboard_app/reusable/lovat_api/lovat_api.dart';
 import 'package:scouting_dashboard_app/reusable/lovat_api/picklists/get_picklist_analysis.dart';
 import 'package:scouting_dashboard_app/reusable/lovat_api/picklists/mutable/create_mutable_picklist.dart';
@@ -18,23 +19,65 @@ class PicklistWeight {
     this.path,
     this.localizedName, {
     this.value = 0,
+    this.isCustom = false,
   });
 
   String path;
   String localizedName;
   double value;
+  final bool isCustom;
 
   Map<String, dynamic> toMap() => {
         'path': path,
         'localizedName': localizedName,
         'value': value,
+        'isCustom': isCustom,
       };
 
   factory PicklistWeight.fromMap(Map<String, dynamic> map) => PicklistWeight(
         map['path'],
         map['localizedName'],
         value: map['value'],
+        isCustom: map['isCustom'] ?? false,
       );
+}
+
+/// Builds the full list of picklist weights (all at value 0): the built-in
+/// [picklistWeights] plus one weight per NUMBER-type custom field in
+/// [fields]. Archived fields are labeled "(archived)" and excluded entirely
+/// when [includeArchived] is false.
+List<PicklistWeight> allPicklistWeightsFromFields(
+  List<CustomField> fields, {
+  bool includeArchived = true,
+}) {
+  return [
+    ...picklistWeights
+        .map((weight) => PicklistWeight(weight.path, weight.localizedName)),
+    ...fields
+        .where((field) =>
+            field.type == CustomFieldType.number &&
+            (includeArchived || !field.archived))
+        .map((field) => PicklistWeight(
+              field.cfPath,
+              field.archived ? '${field.name} (archived)' : field.name,
+              isCustom: true,
+            )),
+  ];
+}
+
+/// All available picklist weights: the built-in [picklistWeights] plus the
+/// team's NUMBER-type custom fields. Falls back to just the built-ins when
+/// the custom field definitions can't be fetched.
+Future<List<PicklistWeight>> getAllPicklistWeights({
+  bool includeArchived = true,
+}) async {
+  List<CustomField> fields;
+  try {
+    fields = await getCustomFieldDefinitions();
+  } catch (_) {
+    fields = [];
+  }
+  return allPicklistWeightsFromFields(fields, includeArchived: includeArchived);
 }
 
 class ConfiguredPicklist {
@@ -91,18 +134,50 @@ class ConfiguredPicklist {
     );
   }
 
-  factory ConfiguredPicklist.fromServerJSON(String json) {
+  factory ConfiguredPicklist.fromServerJSON(
+    String json, {
+    List<PicklistWeight>? allWeights,
+  }) {
     Map<String, dynamic> map = jsonDecode(json);
+
+    final Map<String, dynamic> customFieldWeights =
+        map['customFieldWeights'] is Map
+            ? Map<String, dynamic>.from(map['customFieldWeights'])
+            : {};
+
+    double valueForPath(String path) {
+      final value =
+          path.startsWith('cf_') ? customFieldWeights[path] : map[path];
+      return (value ?? 0).toDouble();
+    }
+
+    final weights = (allWeights ?? picklistWeights)
+        .map((weight) => PicklistWeight(
+              weight.path,
+              weight.localizedName,
+              value: valueForPath(weight.path),
+              isCustom: weight.isCustom,
+            ))
+        .toList();
+
+    // Custom field weights stored on the server but not in [allWeights]
+    // (e.g. when the definitions fetch failed) still get rows so their
+    // values are preserved; the raw path stands in for the name.
+    final knownPaths = weights.map((e) => e.path).toSet();
+    for (final path in customFieldWeights.keys) {
+      if (path.startsWith('cf_') && !knownPaths.contains(path)) {
+        weights.add(PicklistWeight(
+          path,
+          path,
+          value: valueForPath(path),
+          isCustom: true,
+        ));
+      }
+    }
 
     return ConfiguredPicklist(
       map['name'],
-      picklistWeights
-          .map((weight) => PicklistWeight(
-                weight.path,
-                weight.localizedName,
-                value: (map[weight.path] ?? 0).toDouble(),
-              ))
-          .toList(),
+      weights,
       map['uuid'],
       author: map.containsKey('userName') ? map['userName'] : null,
     );

--- a/lib/pages/picklist/picklist_team_breakdown.dart
+++ b/lib/pages/picklist/picklist_team_breakdown.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:scouting_dashboard_app/constants.dart';
 import 'package:scouting_dashboard_app/datatypes.dart';
 import 'package:scouting_dashboard_app/pages/picklist/picklist_models.dart';
+import 'package:scouting_dashboard_app/reusable/custom_field_indicator.dart';
+import 'package:scouting_dashboard_app/reusable/lovat_api/custom_fields.dart';
 import 'package:scouting_dashboard_app/reusable/lovat_api/picklists/get_picklist_analysis.dart';
 import 'package:scouting_dashboard_app/reusable/page_body.dart';
 
@@ -16,6 +18,47 @@ class PicklistTeamBreakdownPage extends StatefulWidget {
 class _PicklistTeamBreakdownPageState extends State<PicklistTeamBreakdownPage> {
   bool useSameHeights = false;
   bool weighted = true;
+
+  @override
+  void initState() {
+    super.initState();
+    loadCustomFieldDefinitions();
+  }
+
+  /// Ensures custom field definitions are cached so `cf_` weight paths
+  /// resolve to their field names.
+  Future<void> loadCustomFieldDefinitions() async {
+    if (cachedCustomFields != null) return;
+
+    try {
+      await getCustomFieldDefinitions();
+    } catch (_) {
+      return;
+    }
+
+    if (mounted) setState(() {});
+  }
+
+  PicklistWeight resolveWeight(String type) {
+    return picklistWeights.firstWhere(
+      (e) => e.path == type,
+      orElse: () {
+        if (type.startsWith('cf_')) {
+          final uuid = type.substring('cf_'.length);
+          final matches =
+              (cachedCustomFields ?? []).where((field) => field.uuid == uuid);
+
+          return PicklistWeight(
+            type,
+            matches.isEmpty ? type : matches.first.name,
+            isCustom: true,
+          );
+        }
+
+        return PicklistWeight(type, type);
+      },
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -77,6 +120,8 @@ class _PicklistTeamBreakdownPageState extends State<PicklistTeamBreakdownPage> {
                   ? activeList.indexOf(weight).isOdd
                   : activeList.indexOf(weight).isEven;
 
+              final resolvedWeight = resolveWeight(weight.type);
+
               return AnimatedContainer(
                 duration: const Duration(milliseconds: 300),
                 curve: Curves.easeInOutCubicEmphasized,
@@ -99,20 +144,33 @@ class _PicklistTeamBreakdownPageState extends State<PicklistTeamBreakdownPage> {
                       crossAxisAlignment: CrossAxisAlignment.center,
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
-                        Text(
-                          picklistWeights
-                              .firstWhere((e) => e.path == weight.type,
-                                  orElse: () =>
-                                      PicklistWeight(weight.type, weight.type))
-                              .localizedName,
-                          overflow: TextOverflow.clip,
-                          style: Theme.of(context).textTheme.titleMedium!.merge(
-                              TextStyle(
-                                  color: alternate
-                                      ? Theme.of(context).colorScheme.onPrimary
-                                      : Theme.of(context)
-                                          .colorScheme
-                                          .onPrimaryContainer)),
+                        Expanded(
+                          child: Row(
+                            children: [
+                              Flexible(
+                                child: Text(
+                                  resolvedWeight.localizedName,
+                                  overflow: TextOverflow.clip,
+                                  style: Theme.of(context)
+                                      .textTheme
+                                      .titleMedium!
+                                      .merge(TextStyle(
+                                          color: alternate
+                                              ? Theme.of(context)
+                                                  .colorScheme
+                                                  .onPrimary
+                                              : Theme.of(context)
+                                                  .colorScheme
+                                                  .onPrimaryContainer)),
+                                ),
+                              ),
+                              if (resolvedWeight.isCustom ||
+                                  weight.type.startsWith('cf_')) ...[
+                                const SizedBox(width: 8),
+                                const CustomFieldIndicator(),
+                              ],
+                            ],
+                          ),
                         ),
                         Text(
                           weight.result.toStringAsFixed(2),

--- a/lib/pages/picklist/view_picklist_weights.dart
+++ b/lib/pages/picklist/view_picklist_weights.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:scouting_dashboard_app/pages/picklist/picklist_models.dart';
+import 'package:scouting_dashboard_app/reusable/custom_field_indicator.dart';
 import 'package:scouting_dashboard_app/reusable/friendly_error_view.dart';
 import 'package:scouting_dashboard_app/reusable/lovat_api/lovat_api.dart';
 import 'package:scouting_dashboard_app/reusable/lovat_api/picklists/shared/get_shared_picklist_by_id.dart';
@@ -68,7 +69,21 @@ class _ViewPicklistWeightsPageState extends State<ViewPicklistWeightsPage> {
               .map((weight) => Column(
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
-                      Text(weight.localizedName),
+                      Row(
+                        children: [
+                          Flexible(
+                            child: Text(
+                              weight.localizedName,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                          if (weight.isCustom ||
+                              weight.path.startsWith('cf_')) ...[
+                            const SizedBox(width: 8),
+                            const CustomFieldIndicator(),
+                          ],
+                        ],
+                      ),
                       Slider(
                           value: weight.value, onChanged: null, min: 0, max: 1)
                     ],

--- a/lib/pages/raw_scout_report.dart
+++ b/lib/pages/raw_scout_report.dart
@@ -533,8 +533,21 @@ class _RawScoutReportPageState extends State<RawScoutReportPage> {
           ],
         ),
         if (reportAnalysis.customFieldAnswers.isNotEmpty) ...[
-          const SectionTitle("Asked by your team"),
-          ...reportAnalysis.customFieldAnswers.map(customFieldAnswer),
+          SectionTitle(
+            reportAnalysis.customFieldsAreOwnTeam
+                ? "Asked by your team"
+                : "Asked by ${reportAnalysis.customFieldsSourceTeam}",
+          ),
+          // One group so the section title sits as close to the first answer as
+          // built-in sections do, with uniform spacing between answers of any
+          // type (text, number, select).
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            spacing: 12,
+            children: reportAnalysis.customFieldAnswers
+                .map(customFieldAnswer)
+                .toList(),
+          ),
         ],
         if (reportAnalysis.notes != null)
           Column(
@@ -575,39 +588,72 @@ class _RawScoutReportPageState extends State<RawScoutReportPage> {
   }
 
   Widget customFieldAnswer(CustomFieldAnswerDisplay answer) {
+    // Scouting leads of the report's team can fix a typed answer's text.
+    final canEdit = answer.type == CustomFieldType.text &&
+        (reportAnalysis?.canModify ?? false) &&
+        answer.uuid != null;
+
+    final String value;
     switch (answer.type) {
       case CustomFieldType.text:
-        return Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
+        value = answer.textValue ?? "";
+        break;
+      case CustomFieldType.number:
+        value = numToStringRounded(answer.numberValue);
+        break;
+      case CustomFieldType.singleSelect:
+        value = answer.selections.isNotEmpty ? answer.selections.first : "";
+        break;
+      case CustomFieldType.multiSelect:
+        value = answer.selections.join(", ");
+        break;
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        // A field label, deliberately smaller than the built-in section
+        // headings so it doesn't read as a built-in metric.
+        Row(
           children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(vertical: 10),
+            // Already grouped under the "Asked by your team" heading, so the
+            // question name alone suffices — no separate Custom badge needed.
+            Expanded(
               child: Text(
                 answer.name,
-                style: Theme.of(context).textTheme.headlineMedium!.copyWith(
+                style: Theme.of(context).textTheme.titleMedium!.copyWith(
                       color: Theme.of(context).colorScheme.onSurface,
+                      fontWeight: FontWeight.w600,
                     ),
               ),
             ),
-            Text(answer.textValue!),
+            if (canEdit)
+              // Tightly constrained so the edit affordance doesn't inflate
+              // the label row taller than a plain (non-text) answer's label.
+              IconButton(
+                icon: const Icon(Icons.edit, size: 20),
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(minWidth: 36, minHeight: 28),
+                visualDensity: VisualDensity.compact,
+                onPressed: () {
+                  Navigator.of(context).pushWidget(NotesEditor(
+                    title: "Edit answer",
+                    initialNotes: answer.textValue,
+                    uuid: answer.uuid,
+                    onSubmit: (v) =>
+                        lovatAPI.updateCustomFieldAnswer(answer.uuid!, v),
+                    onSubmitted: () => fetchData(),
+                  ));
+                },
+              ),
           ],
-        );
-      case CustomFieldType.number:
-        return ValueTile(
-          value: Text(numToStringRounded(answer.numberValue)),
-          label: Text(answer.name),
-        );
-      case CustomFieldType.singleSelect:
-        return ValueTile(
-          value: Text(answer.selections.first),
-          label: Text(answer.name),
-        );
-      case CustomFieldType.multiSelect:
-        return ValueTile(
-          value: Text(answer.selections.join(", ")),
-          label: Text(answer.name),
-        );
-    }
+        ),
+        const SizedBox(height: 2),
+        // Match the built-in Notes body (default text style) so custom
+        // answers and notes read at the same size.
+        Text(value),
+      ],
+    );
   }
 
   Widget robotBrokeBox(String description) {
@@ -995,11 +1041,20 @@ class NotesEditor extends StatefulWidget {
     super.key,
     this.initialNotes,
     this.onSubmitted,
-    required this.uuid,
+    this.uuid,
+    this.title = "Edit Notes",
+    this.onSubmit,
   });
 
   final String? initialNotes;
-  final String uuid;
+
+  /// Report uuid whose notes are updated when [onSubmit] is not provided.
+  final String? uuid;
+  final String title;
+
+  /// Custom save action for the entered text. When null, the text is saved as
+  /// the report's notes via [uuid].
+  final Future<void> Function(String value)? onSubmit;
   final dynamic Function()? onSubmitted;
 
   @override
@@ -1034,7 +1089,11 @@ class _NotesEditorState extends State<NotesEditor> {
     });
 
     try {
-      await lovatAPI.updateNote(widget.uuid, notes);
+      if (widget.onSubmit != null) {
+        await widget.onSubmit!(notes);
+      } else {
+        await lovatAPI.updateNote(widget.uuid!, notes);
+      }
       if (navigation.canPop()) {
         navigation.pop();
       }
@@ -1058,7 +1117,7 @@ class _NotesEditorState extends State<NotesEditor> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-          title: const Text("Edit Notes"),
+          title: Text(widget.title),
           actions: [
             IconButton(
               icon: const Icon(Icons.check),

--- a/lib/pages/raw_scout_report.dart
+++ b/lib/pages/raw_scout_report.dart
@@ -278,7 +278,11 @@ class _RawScoutReportPageState extends State<RawScoutReportPage> {
             ),
           ),
           actions: [
-            if (widget.canModify == null || widget.canModify!)
+            // Gate on the report's own fetched permission (same value the
+            // custom-answer editor uses), not the caller-supplied hint — which
+            // is only a heuristic when opened from the Notes tab and would show
+            // Delete/Edit to a non-lead own-team member the server then rejects.
+            if (reportAnalysis!.canModify)
               IconButton(
                 icon: const Icon(Icons.delete),
                 tooltip: "Delete report",
@@ -567,7 +571,7 @@ class _RawScoutReportPageState extends State<RawScoutReportPage> {
                               ),
                     ),
                   ),
-                  if (widget.canModify == null || widget.canModify!)
+                  if (reportAnalysis.canModify)
                     IconButton(
                       icon: const Icon(Icons.edit),
                       onPressed: () {

--- a/lib/pages/raw_scout_report.dart
+++ b/lib/pages/raw_scout_report.dart
@@ -9,9 +9,11 @@ import 'package:scouting_dashboard_app/reusable/friendly_error_view.dart';
 import 'package:scouting_dashboard_app/reusable/lovat_api/delete_scout_report.dart';
 import 'package:scouting_dashboard_app/reusable/lovat_api/get_events_for_scout_report.dart';
 import 'package:scouting_dashboard_app/reusable/lovat_api/get_scout_report_analysis.dart';
+import 'package:scouting_dashboard_app/reusable/lovat_api/custom_fields.dart';
 import 'package:scouting_dashboard_app/reusable/lovat_api/get_scout_reports_by_long_match_key.dart';
 import 'package:scouting_dashboard_app/reusable/lovat_api/lovat_api.dart';
 import 'package:scouting_dashboard_app/reusable/lovat_api/update_note.dart';
+import 'package:scouting_dashboard_app/reusable/models/custom_field_answer.dart';
 import 'package:scouting_dashboard_app/reusable/models/match.dart';
 import 'package:scouting_dashboard_app/reusable/models/robot_roles.dart';
 import 'package:scouting_dashboard_app/reusable/page_body.dart';
@@ -530,6 +532,10 @@ class _RawScoutReportPageState extends State<RawScoutReportPage> {
                     label: const Text("time left")))
           ],
         ),
+        if (reportAnalysis.customFieldAnswers.isNotEmpty) ...[
+          const SectionTitle("Asked by your team"),
+          ...reportAnalysis.customFieldAnswers.map(customFieldAnswer),
+        ],
         if (reportAnalysis.notes != null)
           Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -566,6 +572,42 @@ class _RawScoutReportPageState extends State<RawScoutReportPage> {
           ),
       ].withSpaceBetween(height: 10),
     );
+  }
+
+  Widget customFieldAnswer(CustomFieldAnswerDisplay answer) {
+    switch (answer.type) {
+      case CustomFieldType.text:
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 10),
+              child: Text(
+                answer.name,
+                style: Theme.of(context).textTheme.headlineMedium!.copyWith(
+                      color: Theme.of(context).colorScheme.onSurface,
+                    ),
+              ),
+            ),
+            Text(answer.textValue!),
+          ],
+        );
+      case CustomFieldType.number:
+        return ValueTile(
+          value: Text(numToStringRounded(answer.numberValue)),
+          label: Text(answer.name),
+        );
+      case CustomFieldType.singleSelect:
+        return ValueTile(
+          value: Text(answer.selections.first),
+          label: Text(answer.name),
+        );
+      case CustomFieldType.multiSelect:
+        return ValueTile(
+          value: Text(answer.selections.join(", ")),
+          label: Text(answer.name),
+        );
+    }
   }
 
   Widget robotBrokeBox(String description) {

--- a/lib/pages/raw_scout_report.dart
+++ b/lib/pages/raw_scout_report.dart
@@ -540,7 +540,9 @@ class _RawScoutReportPageState extends State<RawScoutReportPage> {
           SectionTitle(
             reportAnalysis.customFieldsAreOwnTeam
                 ? "Asked by your team"
-                : "Asked by ${reportAnalysis.customFieldsSourceTeam}",
+                : reportAnalysis.customFieldsSourceTeam != null
+                    ? "Asked by ${reportAnalysis.customFieldsSourceTeam}"
+                    : "Asked by another team",
           ),
           // One group so the section title sits as close to the first answer as
           // built-in sections do, with uniform spacing between answers of any

--- a/lib/pages/team_lookup/tabs/team_lookup_breakdowns.dart
+++ b/lib/pages/team_lookup/tabs/team_lookup_breakdowns.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:scouting_dashboard_app/metrics.dart';
 import 'package:scouting_dashboard_app/pages/team_lookup/team_lookup_breakdown_details.dart';
+import 'package:scouting_dashboard_app/reusable/custom_field_indicator.dart';
 import 'package:scouting_dashboard_app/reusable/friendly_error_view.dart';
 import 'package:scouting_dashboard_app/reusable/lovat_api/lovat_api.dart';
 import 'package:scouting_dashboard_app/reusable/lovat_api/team_lookup/get_breakdown_metrics.dart';
@@ -24,10 +25,15 @@ class TeamLookupBreakdownsTab extends StatelessWidget {
         final data = result.data;
         final error = result.error;
         if (data != null) {
+          final allBreakdowns = [
+            ...breakdowns,
+            ...customFieldBreakdowns(data),
+          ];
+
           return Stack(
             children: [
               ScrollablePageBody(
-                children: breakdowns
+                children: allBreakdowns
                     .map(
                       (BreakdownData breakdownData) => Breakdown(
                         dataIdentity: breakdownData,
@@ -113,6 +119,31 @@ class TeamLookupBreakdownsTab extends StatelessWidget {
   }
 }
 
+/// Builds breakdowns for the viewing team's custom select fields from the
+/// `customFields` metadata the server includes inline in the breakdown metrics
+/// response, with one segment per option (in options order) plus segments for
+/// any recorded answer no longer among the field's current options.
+List<BreakdownData> customFieldBreakdowns(BreakdownMetrics data) {
+  return data.customFields.map((field) {
+    final answerKeys =
+        data.breakdown(field.metricKey)?.keys ?? const <String>[];
+
+    return BreakdownData(
+      localizedName: field.name,
+      path: field.metricKey,
+      segments: [
+        ...field.options,
+        ...answerKeys.where((key) => !field.options.contains(key)),
+      ]
+          .map((option) => BreakdownSegmentData(
+                localizedNameSingular: option,
+                path: option,
+              ))
+          .toList(),
+    );
+  }).toList();
+}
+
 class Breakdown extends StatelessWidget {
   const Breakdown({
     super.key,
@@ -145,15 +176,31 @@ class Breakdown extends StatelessWidget {
                   Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
-                      Text(
-                        dataIdentity.localizedName,
-                        style: Theme.of(context).textTheme.titleMedium!.merge(
-                              TextStyle(
-                                color: Theme.of(context)
-                                    .colorScheme
-                                    .onSurfaceVariant,
+                      Expanded(
+                        child: Row(
+                          children: [
+                            Flexible(
+                              child: Text(
+                                dataIdentity.localizedName,
+                                overflow: TextOverflow.ellipsis,
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .titleMedium!
+                                    .merge(
+                                      TextStyle(
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .onSurfaceVariant,
+                                      ),
+                                    ),
                               ),
                             ),
+                            if (dataIdentity.path.startsWith('cf_')) ...[
+                              const SizedBox(width: 8),
+                              const CustomFieldIndicator(),
+                            ],
+                          ],
+                        ),
                       ),
                       Icon(
                         Icons.navigate_next,

--- a/lib/pages/team_lookup/tabs/team_lookup_categories.dart
+++ b/lib/pages/team_lookup/tabs/team_lookup_categories.dart
@@ -22,12 +22,18 @@ class TeamLookupCategoriesTab extends StatelessWidget {
         final data = result.data;
         final error = result.error;
         if (data != null) {
+          final customFieldCategory = customFieldMetricCategory(data);
+          final allCategories = [
+            ...metricCategories,
+            if (customFieldCategory != null) customFieldCategory,
+          ];
+
           return Stack(
             children: [
               ScrollablePageBody(
                 children: [
                   MetricCategoryList(
-                    metricCategories: metricCategories
+                    metricCategories: allCategories
                         .map((category) => MetricCategory(
                               categoryName: category.localizedName,
                               metricTiles: category.metrics
@@ -150,6 +156,39 @@ class TeamLookupCategoriesTab extends StatelessWidget {
       },
     );
   }
+}
+
+/// Builds an "Asked by your team" category from the `customFields` metadata
+/// array the server includes inline in the category metrics response (entries
+/// like `{uuid, metricKey, name, order, average}`), or null when the viewing
+/// team has no answered custom number fields. The tiles read their values from
+/// the flat `cf_<uuid>` keys of the response, exactly like built-in metrics.
+MetricCategoryData? customFieldMetricCategory(CategoryMetrics data) {
+  final metadata = data.valueForPath('customFields');
+  if (metadata is! List) return null;
+
+  final entries = metadata
+      .whereType<Map<String, dynamic>>()
+      .where(
+          (entry) => entry['metricKey'] is String && entry['name'] is String)
+      .toList();
+
+  if (entries.isEmpty) return null;
+
+  entries.sort((a, b) =>
+      ((a['order'] as num?) ?? 0).compareTo((b['order'] as num?) ?? 0));
+
+  return MetricCategoryData(
+    "Asked by your team",
+    entries
+        .map((entry) => CategoryMetric(
+              localizedName: entry['name'],
+              abbreviatedLocalizedName: entry['name'],
+              path: entry['metricKey'],
+              hideFlag: true,
+            ))
+        .toList(),
+  );
 }
 
 class MetricCategoryList extends StatelessWidget {

--- a/lib/pages/team_lookup/tabs/team_lookup_notes.dart
+++ b/lib/pages/team_lookup/tabs/team_lookup_notes.dart
@@ -342,7 +342,10 @@ class NoteWidget extends StatelessWidget {
                               ),
                             ),
                             const SizedBox(width: 8),
-                            const CustomFieldIndicator(),
+                            CustomFieldIndicator(
+                              backgroundColor: scheme.primary,
+                              foregroundColor: scheme.onPrimary,
+                            ),
                           ],
                         ),
                         const SizedBox(height: 3),
@@ -488,47 +491,55 @@ class _ExpandableTextState extends State<ExpandableText> {
         return Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // The full text is always laid out; only the revealed height
-            // animates and clips it, so the text never snaps when collapsing.
-            TweenAnimationBuilder<double>(
-              tween:
-                  Tween<double>(end: expanded ? fullHeight : collapsedHeight),
-              duration: _duration,
-              curve: _curve,
-              child: Text(widget.text, style: widget.style),
-              builder: (context, height, child) {
-                Widget clipped = ClipRect(
-                  child: SizedBox(
-                    height: height,
-                    width: double.infinity,
-                    child: OverflowBox(
-                      alignment: Alignment.topLeft,
-                      minHeight: 0,
-                      maxHeight: double.infinity,
-                      child: child,
+            // Tapping the body text itself toggles expansion, same as the
+            // button. This GestureDetector sits inside the note card's InkWell
+            // and claims taps on the text region, so only taps elsewhere on the
+            // card (match name, custom answers, etc.) open the raw report.
+            GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: () => _toggle(maxWidth),
+              // The full text is always laid out; only the revealed height
+              // animates and clips it, so the text never snaps when collapsing.
+              child: TweenAnimationBuilder<double>(
+                tween:
+                    Tween<double>(end: expanded ? fullHeight : collapsedHeight),
+                duration: _duration,
+                curve: _curve,
+                child: Text(widget.text, style: widget.style),
+                builder: (context, height, child) {
+                  Widget clipped = ClipRect(
+                    child: SizedBox(
+                      height: height,
+                      width: double.infinity,
+                      child: OverflowBox(
+                        alignment: Alignment.topLeft,
+                        minHeight: 0,
+                        maxHeight: double.infinity,
+                        child: child,
+                      ),
                     ),
-                  ),
-                );
-                // Soft-fade the bottom edge while any text is still hidden.
-                if (height < fullHeight - 0.5) {
-                  final fadeStop = (1 - (18 / height)).clamp(0.0, 1.0);
-                  clipped = ShaderMask(
-                    blendMode: BlendMode.dstIn,
-                    shaderCallback: (rect) => LinearGradient(
-                      begin: Alignment.topCenter,
-                      end: Alignment.bottomCenter,
-                      colors: const [
-                        Colors.white,
-                        Colors.white,
-                        Colors.transparent,
-                      ],
-                      stops: [0.0, fadeStop, 1.0],
-                    ).createShader(rect),
-                    child: clipped,
                   );
-                }
-                return clipped;
-              },
+                  // Soft-fade the bottom edge while any text is still hidden.
+                  if (height < fullHeight - 0.5) {
+                    final fadeStop = (1 - (18 / height)).clamp(0.0, 1.0);
+                    clipped = ShaderMask(
+                      blendMode: BlendMode.dstIn,
+                      shaderCallback: (rect) => LinearGradient(
+                        begin: Alignment.topCenter,
+                        end: Alignment.bottomCenter,
+                        colors: const [
+                          Colors.white,
+                          Colors.white,
+                          Colors.transparent,
+                        ],
+                        stops: [0.0, fadeStop, 1.0],
+                      ).createShader(rect),
+                      child: clipped,
+                    );
+                  }
+                  return clipped;
+                },
+              ),
             ),
             const SizedBox(height: 3),
             GestureDetector(

--- a/lib/pages/team_lookup/tabs/team_lookup_notes.dart
+++ b/lib/pages/team_lookup/tabs/team_lookup_notes.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:scouting_dashboard_app/pages/raw_scout_report.dart';
+import 'package:scouting_dashboard_app/reusable/custom_field_indicator.dart';
 import 'package:scouting_dashboard_app/reusable/emphasized_container.dart';
 import 'package:scouting_dashboard_app/reusable/friendly_error_view.dart';
 import 'package:scouting_dashboard_app/reusable/lovat_api/lovat_api.dart';
@@ -290,14 +291,65 @@ class NoteWidget extends StatelessWidget {
                 ],
               ],
             ),
-            Text(
-              note.body,
-              style: Theme.of(context).textTheme.bodyMedium!.merge(
-                    TextStyle(
-                      color: foregroundColor ??
-                          Theme.of(context).colorScheme.onPrimaryContainer,
+            if (note.body.isNotEmpty)
+              Text(
+                note.body,
+                style: Theme.of(context).textTheme.bodyMedium!.merge(
+                      TextStyle(
+                        color: foregroundColor ??
+                            Theme.of(context).colorScheme.onPrimaryContainer,
+                      ),
                     ),
-                  ),
+              ),
+            // Text custom field answers from the same report, each below a
+            // divider and labeled with its question + the Custom marker.
+            ...note.customTextAnswers.map(
+              (answer) => Padding(
+                padding: const EdgeInsets.only(top: 10),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Divider(
+                      height: 1,
+                      color: (foregroundColor ??
+                              Theme.of(context).colorScheme.onPrimaryContainer)
+                          .withValues(alpha: 0.25),
+                    ),
+                    const SizedBox(height: 8),
+                    Row(
+                      children: [
+                        Flexible(
+                          child: Text(
+                            answer.name,
+                            style: Theme.of(context).textTheme.labelLarge!.merge(
+                                  TextStyle(
+                                    color: foregroundColor ??
+                                        Theme.of(context)
+                                            .colorScheme
+                                            .onPrimaryContainer,
+                                  ),
+                                ),
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        const CustomFieldIndicator(),
+                      ],
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      answer.value,
+                      style: Theme.of(context).textTheme.bodyMedium!.merge(
+                            TextStyle(
+                              color: foregroundColor ??
+                                  Theme.of(context)
+                                      .colorScheme
+                                      .onPrimaryContainer,
+                            ),
+                          ),
+                    ),
+                  ],
+                ),
+              ),
             ),
             if (note.author != null) ...[
               const SizedBox(height: 4),

--- a/lib/pages/team_lookup/tabs/team_lookup_notes.dart
+++ b/lib/pages/team_lookup/tabs/team_lookup_notes.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:scouting_dashboard_app/pages/raw_scout_report.dart';
 import 'package:scouting_dashboard_app/reusable/custom_field_indicator.dart';
 import 'package:scouting_dashboard_app/reusable/emphasized_container.dart';
 import 'package:scouting_dashboard_app/reusable/friendly_error_view.dart';
@@ -26,9 +25,13 @@ class TeamLookupNotesTab extends StatelessWidget {
         final error = result.error;
         final refetch = result.refetch;
         if (data != null) {
+          // Tag each note with the team being looked up so its card can open
+          // the matching raw scout report.
+          final withTeam =
+              data.map((e) => e.copyWith(teamNumber: team)).toList();
           final sortedNotes = [
-            ...data.where((e) => e.type == NoteType.breakDescription),
-            ...data.where((e) => e.type != NoteType.breakDescription),
+            ...withTeam.where((e) => e.type == NoteType.breakDescription),
+            ...withTeam.where((e) => e.type != NoteType.breakDescription),
           ];
           return Stack(
             children: [
@@ -241,134 +244,308 @@ class NoteWidget extends StatelessWidget {
   final Color? foregroundColor;
   @override
   Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    // Colour roles for hierarchy: an accent for the match and field labels, a
+    // high-contrast colour for the note body, and a muted colour for secondary
+    // metadata (tournament, attribution). Break descriptions pass a foreground
+    // colour that overrides all three.
+    // Neutral "plain" card (the app's default EmphasizedContainer surface) so
+    // the body reads as standard on-surface text rather than white-on-purple.
+    final bodyColor = foregroundColor ?? scheme.onSurface;
+    final mutedColor =
+        foregroundColor?.withValues(alpha: 0.75) ?? scheme.onSurfaceVariant;
+
+    final matchLabel =
+        note.matchIdentity.getLocalizedDescription(includeTournament: false);
+    final attribution = note.author ??
+        (note.sourceTeam != null ? "Scouter from ${note.sourceTeam}" : null);
+    // A note links to its raw scout report when we know both ids.
+    final canOpen = note.uuid != null && note.teamNumber != null;
+
     return Container(
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(10),
-        color:
-            backgroundColor ?? Theme.of(context).colorScheme.primaryContainer,
-      ),
-      child: Padding(
-        padding: const EdgeInsets.all(15),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
+      clipBehavior: Clip.antiAlias,
+      decoration: BoxDecoration(borderRadius: BorderRadius.circular(10)),
+      child: Material(
+        color: backgroundColor ?? scheme.surfaceContainerHighest,
+        child: InkWell(
+          onTap: canOpen ? () => _openRawReport(context) : null,
+          child: Padding(
+            padding: const EdgeInsets.all(15),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                Flexible(
-                  child: Text(
-                    note.type == NoteType.breakDescription
-                        ? "Robot broke in ${note.matchIdentity.getLocalizedDescription(abbreviateName: true)}"
-                        : note.matchIdentity.getLocalizedDescription(),
-                    style: Theme.of(context).textTheme.titleMedium!.merge(
-                          TextStyle(
-                            color: foregroundColor ??
-                                Theme.of(context)
-                                    .colorScheme
-                                    .onPrimaryContainer,
+                // Header: match-type icon + concise match name, with the (longer)
+                // tournament name beneath it, de-emphasised.
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            matchLabel,
+                            style: textTheme.titleMedium!.copyWith(
+                              color: bodyColor,
+                              fontWeight: FontWeight.w600,
+                            ),
                           ),
+                          Text(
+                            note.matchIdentity.localizedTournament,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: textTheme.bodySmall!
+                                .copyWith(color: mutedColor),
+                          ),
+                        ],
+                      ),
+                    ),
+                    if (canOpen)
+                      Padding(
+                        padding: const EdgeInsets.only(left: 8, top: 2),
+                        child: Icon(
+                          Icons.chevron_right,
+                          color: mutedColor,
+                          size: 22,
                         ),
+                      ),
+                  ],
+                ),
+                if (note.body.isNotEmpty) ...[
+                  const SizedBox(height: 6),
+                  ExpandableText(
+                    note.body,
+                    style: textTheme.bodyMedium!
+                        .copyWith(color: bodyColor, height: 1.3),
+                    linkColor: foregroundColor ?? scheme.onPrimaryContainer,
+                  ),
+                ],
+                // Text custom field answers from the same report, set off by a
+                // gap and labelled with the question + the Custom marker.
+                ...note.customTextAnswers.map(
+                  (answer) => Padding(
+                    padding: const EdgeInsets.only(top: 8),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Row(
+                          children: [
+                            Flexible(
+                              child: Text(
+                                answer.name,
+                                style: textTheme.labelLarge!.copyWith(
+                                  color: bodyColor,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                            ),
+                            const SizedBox(width: 8),
+                            const CustomFieldIndicator(),
+                          ],
+                        ),
+                        const SizedBox(height: 3),
+                        Text(
+                          answer.value,
+                          style: textTheme.bodyMedium!
+                              .copyWith(color: bodyColor, height: 1.3),
+                        ),
+                      ],
+                    ),
                   ),
                 ),
-                if (note.uuid != null) ...[
-                  IconButton(
-                    onPressed: () {
-                      Navigator.of(context).pushWidget(
-                        NotesEditor(
-                          uuid: note.uuid!,
-                          initialNotes: note.body,
-                          onSubmitted: () => onEdit?.call(),
+                if (attribution != null) ...[
+                  const SizedBox(height: 10),
+                  Row(
+                    children: [
+                      Icon(
+                        Icons.account_circle,
+                        size: 15,
+                        color: mutedColor,
+                      ),
+                      const SizedBox(width: 5),
+                      Flexible(
+                        child: Text(
+                          attribution,
+                          // Same style as the tournament line so they match.
+                          style:
+                              textTheme.bodySmall!.copyWith(color: mutedColor),
                         ),
-                      );
-                    },
-                    icon: Icon(
-                      Icons.edit_outlined,
-                      color: foregroundColor ??
-                          Theme.of(context).colorScheme.onPrimaryContainer,
-                    ),
-                    visualDensity: VisualDensity.compact,
+                      ),
+                    ],
                   ),
                 ],
               ],
             ),
-            if (note.body.isNotEmpty)
-              Text(
-                note.body,
-                style: Theme.of(context).textTheme.bodyMedium!.merge(
-                      TextStyle(
-                        color: foregroundColor ??
-                            Theme.of(context).colorScheme.onPrimaryContainer,
-                      ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _openRawReport(BuildContext context) {
+    Navigator.of(context).pushNamed(
+      '/raw_scout_report',
+      arguments: {
+        'uuid': note.uuid,
+        'teamNumber': note.teamNumber,
+        'matchIdentity': note.matchIdentity,
+        'scoutName': note.author ??
+            (note.sourceTeam != null
+                ? "Scouter from ${note.sourceTeam}"
+                : "Unknown scout"),
+        'canModify': note.author != null,
+        'onDeleted': () => onEdit?.call(),
+      },
+    );
+  }
+}
+
+/// A note body that clamps to [maxLines] with a "Read more" / "Read less"
+/// toggle when the text would otherwise overflow.
+class ExpandableText extends StatefulWidget {
+  const ExpandableText(
+    this.text, {
+    super.key,
+    this.style,
+    this.maxLines = 5,
+    this.linkColor,
+  });
+
+  final String text;
+  final TextStyle? style;
+  final int maxLines;
+  final Color? linkColor;
+
+  @override
+  State<ExpandableText> createState() => _ExpandableTextState();
+}
+
+class _ExpandableTextState extends State<ExpandableText> {
+  static const _duration = Duration(milliseconds: 250);
+  static const _curve = Curves.easeInOut;
+
+  bool expanded = false;
+  final GlobalKey _buttonKey = GlobalKey();
+
+  double _textHeight(int? maxLines, double maxWidth) {
+    return (TextPainter(
+      text: TextSpan(text: widget.text, style: widget.style),
+      maxLines: maxLines,
+      textDirection: Directionality.of(context),
+    )..layout(maxWidth: maxWidth))
+        .height;
+  }
+
+  void _toggle(double maxWidth) {
+    if (expanded) {
+      // Collapsing shrinks the text above the button by `delta`. Only scroll
+      // the list up (to keep the button under the finger) if the button would
+      // otherwise be pushed above the top of the viewport.
+      final delta =
+          _textHeight(null, maxWidth) - _textHeight(widget.maxLines, maxWidth);
+      final scrollable = Scrollable.maybeOf(context);
+      final buttonBox =
+          _buttonKey.currentContext?.findRenderObject() as RenderBox?;
+      final viewportBox = scrollable?.context.findRenderObject() as RenderBox?;
+      if (scrollable != null &&
+          buttonBox != null &&
+          viewportBox != null &&
+          delta > 0) {
+        const margin = 12.0;
+        final viewportTop = viewportBox.localToGlobal(Offset.zero).dy;
+        // Where the button will sit once the text above it collapses.
+        final projectedButtonTop =
+            buttonBox.localToGlobal(Offset.zero).dy - delta;
+        if (projectedButtonTop < viewportTop + margin) {
+          // Scroll up only far enough to bring it back on-screen (the minimum),
+          // rather than all the way back to where it started.
+          final scrollUpBy = (viewportTop + margin) - projectedButtonTop;
+          final position = scrollable.position;
+          final target = (position.pixels - scrollUpBy)
+              .clamp(position.minScrollExtent, position.maxScrollExtent);
+          position.animateTo(target, duration: _duration, curve: _curve);
+        }
+      }
+    }
+    setState(() => expanded = !expanded);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final maxWidth = constraints.maxWidth;
+        final fullHeight = _textHeight(null, maxWidth);
+        final collapsedHeight = _textHeight(widget.maxLines, maxWidth);
+
+        // Short enough that nothing is clipped.
+        if (fullHeight <= collapsedHeight + 0.5) {
+          return Text(widget.text, style: widget.style);
+        }
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // The full text is always laid out; only the revealed height
+            // animates and clips it, so the text never snaps when collapsing.
+            TweenAnimationBuilder<double>(
+              tween:
+                  Tween<double>(end: expanded ? fullHeight : collapsedHeight),
+              duration: _duration,
+              curve: _curve,
+              child: Text(widget.text, style: widget.style),
+              builder: (context, height, child) {
+                Widget clipped = ClipRect(
+                  child: SizedBox(
+                    height: height,
+                    width: double.infinity,
+                    child: OverflowBox(
+                      alignment: Alignment.topLeft,
+                      minHeight: 0,
+                      maxHeight: double.infinity,
+                      child: child,
                     ),
-              ),
-            // Text custom field answers from the same report, each below a
-            // divider and labeled with its question + the Custom marker.
-            ...note.customTextAnswers.map(
-              (answer) => Padding(
-                padding: const EdgeInsets.only(top: 10),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    Divider(
-                      height: 1,
-                      color: (foregroundColor ??
-                              Theme.of(context).colorScheme.onPrimaryContainer)
-                          .withValues(alpha: 0.25),
-                    ),
-                    const SizedBox(height: 8),
-                    Row(
-                      children: [
-                        Flexible(
-                          child: Text(
-                            answer.name,
-                            style: Theme.of(context).textTheme.labelLarge!.merge(
-                                  TextStyle(
-                                    color: foregroundColor ??
-                                        Theme.of(context)
-                                            .colorScheme
-                                            .onPrimaryContainer,
-                                  ),
-                                ),
-                          ),
-                        ),
-                        const SizedBox(width: 8),
-                        const CustomFieldIndicator(),
+                  ),
+                );
+                // Soft-fade the bottom edge while any text is still hidden.
+                if (height < fullHeight - 0.5) {
+                  final fadeStop = (1 - (18 / height)).clamp(0.0, 1.0);
+                  clipped = ShaderMask(
+                    blendMode: BlendMode.dstIn,
+                    shaderCallback: (rect) => LinearGradient(
+                      begin: Alignment.topCenter,
+                      end: Alignment.bottomCenter,
+                      colors: const [
+                        Colors.white,
+                        Colors.white,
+                        Colors.transparent,
                       ],
-                    ),
-                    const SizedBox(height: 2),
-                    Text(
-                      answer.value,
-                      style: Theme.of(context).textTheme.bodyMedium!.merge(
-                            TextStyle(
-                              color: foregroundColor ??
-                                  Theme.of(context)
-                                      .colorScheme
-                                      .onPrimaryContainer,
-                            ),
-                          ),
-                    ),
-                  ],
+                      stops: [0.0, fadeStop, 1.0],
+                    ).createShader(rect),
+                    child: clipped,
+                  );
+                }
+                return clipped;
+              },
+            ),
+            const SizedBox(height: 3),
+            GestureDetector(
+              key: _buttonKey,
+              behavior: HitTestBehavior.opaque,
+              onTap: () => _toggle(maxWidth),
+              child: Text(
+                expanded ? "Show less" : "Show more",
+                style: (widget.style ?? const TextStyle()).copyWith(
+                  color: widget.linkColor,
+                  fontWeight: FontWeight.w600,
                 ),
               ),
             ),
-            if (note.author != null) ...[
-              const SizedBox(height: 4),
-              Text(
-                note.author!,
-                style: Theme.of(context).textTheme.bodyMedium!.merge(
-                      TextStyle(
-                        color: foregroundColor?.withValues(alpha: 0.85) ??
-                            Theme.of(context)
-                                .colorScheme
-                                .onPrimaryContainer
-                                .withValues(alpha: 0.7),
-                      ),
-                    ),
-              ),
-            ]
           ],
-        ),
-      ),
+        );
+      },
     );
   }
 }

--- a/lib/reusable/custom_field_indicator.dart
+++ b/lib/reusable/custom_field_indicator.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+/// A small tonal chip marking a value as coming from a team's custom field.
+class CustomFieldIndicator extends StatelessWidget {
+  const CustomFieldIndicator({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: "Asked by your team",
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.secondaryContainer,
+          borderRadius: BorderRadius.circular(4),
+        ),
+        child: Text(
+          "Custom",
+          style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                color: Theme.of(context).colorScheme.onSecondaryContainer,
+              ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/reusable/custom_field_indicator.dart
+++ b/lib/reusable/custom_field_indicator.dart
@@ -11,7 +11,14 @@ class CustomFieldIndicator extends StatelessWidget {
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
         decoration: BoxDecoration(
-          color: Theme.of(context).colorScheme.secondaryContainer,
+          // The container colors in this scheme are identical, so a plain
+          // container fill gives no separation on a *Container background. A
+          // translucent tint of the text color reads as a soft pill on any
+          // background without competing with nearby dividers.
+          color: Theme.of(context)
+              .colorScheme
+              .onSecondaryContainer
+              .withValues(alpha: 0.16),
           borderRadius: BorderRadius.circular(4),
         ),
         child: Text(

--- a/lib/reusable/custom_field_indicator.dart
+++ b/lib/reusable/custom_field_indicator.dart
@@ -2,10 +2,25 @@ import 'package:flutter/material.dart';
 
 /// A small tonal chip marking a value as coming from a team's custom field.
 class CustomFieldIndicator extends StatelessWidget {
-  const CustomFieldIndicator({Key? key}) : super(key: key);
+  const CustomFieldIndicator({
+    Key? key,
+    this.backgroundColor,
+    this.foregroundColor,
+  }) : super(key: key);
+
+  /// Solid fill for the pill. When null, a translucent tint of the default
+  /// text color is used, which reads as a soft pill on any background. Pass an
+  /// opaque color to make it a filled chip (e.g. [ColorScheme.primary] to match
+  /// the "Scouted" flag).
+  final Color? backgroundColor;
+
+  /// Text color. Defaults to [ColorScheme.onSecondaryContainer]. Pair with a
+  /// solid [backgroundColor] to keep contrast (e.g. [ColorScheme.onPrimary]).
+  final Color? foregroundColor;
 
   @override
   Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
     return Tooltip(
       message: "Asked by your team",
       child: Container(
@@ -15,16 +30,14 @@ class CustomFieldIndicator extends StatelessWidget {
           // container fill gives no separation on a *Container background. A
           // translucent tint of the text color reads as a soft pill on any
           // background without competing with nearby dividers.
-          color: Theme.of(context)
-              .colorScheme
-              .onSecondaryContainer
-              .withValues(alpha: 0.16),
+          color: backgroundColor ??
+              scheme.onSecondaryContainer.withValues(alpha: 0.16),
           borderRadius: BorderRadius.circular(4),
         ),
         child: Text(
           "Custom",
           style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                color: Theme.of(context).colorScheme.onSecondaryContainer,
+                color: foregroundColor ?? scheme.onSecondaryContainer,
               ),
         ),
       ),

--- a/lib/reusable/flag_models.dart
+++ b/lib/reusable/flag_models.dart
@@ -252,6 +252,11 @@ class _NetworkFlagState extends State<NetworkFlag> {
     setState(() {
       loaded = false;
       loadingTeam = widget.team;
+      // Drop the previous team's value so it can't leak into the new team's
+      // load: without this, a failed fetch with no cache for the new team hits
+      // the `data == null` guard as false, silently swallowing the error
+      // snackbar and leaving the flag stuck on the skeleton.
+      data = null;
     });
 
     final scaffoldMessengerState = ScaffoldMessenger.of(context);

--- a/lib/reusable/inset_picker.dart
+++ b/lib/reusable/inset_picker.dart
@@ -67,17 +67,24 @@ class InsetPicker<T> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // A null onChanged means the picker is disabled — gray it out so it's
+    // clear the selection can't be changed.
+    final bool disabled = onChanged == null;
+
     return EmphasizedContainer(
       padding: EdgeInsets.zero,
-      child: RadioGroup<T>(
-        groupValue: selectedItem,
-        onChanged:
-            onChanged != null ? (value) => onChanged!(value) : (value) {},
-        child: Column(
-          children: items
-              .map((item) =>
-                  itemSelector(context, item, selected: item == selectedItem))
-              .toList(),
+      child: Opacity(
+        opacity: disabled ? 0.5 : 1.0,
+        child: RadioGroup<T>(
+          groupValue: selectedItem,
+          onChanged:
+              onChanged != null ? (value) => onChanged!(value) : (value) {},
+          child: Column(
+            children: items
+                .map((item) =>
+                    itemSelector(context, item, selected: item == selectedItem))
+                .toList(),
+          ),
         ),
       ),
     );

--- a/lib/reusable/lovat_api/custom_fields.dart
+++ b/lib/reusable/lovat_api/custom_fields.dart
@@ -166,6 +166,25 @@ extension CustomFields on LovatAPI {
     }
   }
 
+  /// Edits the text of a single TEXT custom field answer. Only permitted for
+  /// scouting leads of the field's team (enforced server-side).
+  Future<void> updateCustomFieldAnswer(String answerUuid, String value) async {
+    final response = await put(
+      '/v1/manager/customfields/answers/$answerUuid',
+      body: {'value': value},
+    );
+
+    if (response?.statusCode != 200) {
+      try {
+        throw LovatAPIException(jsonDecode(response!.body)['displayError']);
+      } on LovatAPIException {
+        rethrow;
+      } catch (_) {
+        throw Exception('Failed to update custom field answer');
+      }
+    }
+  }
+
   Future<void> archiveCustomField(String uuid) async {
     final response = await post('/v1/manager/customfields/$uuid/archive');
 

--- a/lib/reusable/lovat_api/custom_fields.dart
+++ b/lib/reusable/lovat_api/custom_fields.dart
@@ -1,0 +1,234 @@
+import 'dart:convert';
+
+import 'package:scouting_dashboard_app/reusable/lovat_api/lovat_api.dart';
+
+enum CustomFieldType {
+  text,
+  number,
+  singleSelect,
+  multiSelect,
+}
+
+extension CustomFieldTypeExtension on CustomFieldType {
+  String get localizedDescription {
+    switch (this) {
+      case CustomFieldType.text:
+        return "Text";
+      case CustomFieldType.number:
+        return "Number";
+      case CustomFieldType.singleSelect:
+        return "Single select";
+      case CustomFieldType.multiSelect:
+        return "Multi select";
+    }
+  }
+
+  String get serverValue {
+    switch (this) {
+      case CustomFieldType.text:
+        return "TEXT";
+      case CustomFieldType.number:
+        return "NUMBER";
+      case CustomFieldType.singleSelect:
+        return "SINGLE_SELECT";
+      case CustomFieldType.multiSelect:
+        return "MULTI_SELECT";
+    }
+  }
+
+  static CustomFieldType fromServerValue(String serverValue) {
+    switch (serverValue) {
+      case "TEXT":
+        return CustomFieldType.text;
+      case "NUMBER":
+        return CustomFieldType.number;
+      case "SINGLE_SELECT":
+        return CustomFieldType.singleSelect;
+      case "MULTI_SELECT":
+        return CustomFieldType.multiSelect;
+      default:
+        throw ArgumentError.value(
+          serverValue,
+          'serverValue',
+          'Unknown custom field type',
+        );
+    }
+  }
+}
+
+class CustomField {
+  const CustomField({
+    required this.uuid,
+    required this.name,
+    required this.type,
+    this.options = const [],
+    this.order = 0,
+    this.archived = false,
+  });
+
+  final String uuid;
+  final String name;
+  final CustomFieldType type;
+  final List<String> options;
+  final int order;
+  final bool archived;
+
+  /// The metric path used for this field in analysis surfaces (`cf_<uuid>`).
+  String get cfPath => 'cf_$uuid';
+
+  factory CustomField.fromJson(Map<String, dynamic> json) {
+    return CustomField(
+      uuid: json['uuid'],
+      name: json['name'],
+      type: CustomFieldTypeExtension.fromServerValue(json['type']),
+      options: List<String>.from(json['options'] ?? []),
+      order: json['order'] ?? 0,
+      archived: json['archived'] ?? false,
+    );
+  }
+}
+
+extension CustomFields on LovatAPI {
+  /// includeArchived - true: include archived fields, false: active fields only
+  Future<List<CustomField>> getCustomFields({
+    bool includeArchived = false,
+  }) async {
+    final response = await get(
+      '/v1/manager/customfields',
+      query: includeArchived ? null : {'archived': 'false'},
+    );
+
+    if (response?.statusCode != 200) {
+      try {
+        throw LovatAPIException(jsonDecode(response!.body)['displayError']);
+      } on LovatAPIException {
+        rethrow;
+      } catch (_) {
+        throw Exception('Failed to get custom fields');
+      }
+    }
+
+    final json = jsonDecode(response!.body) as List<dynamic>;
+
+    final fields = json
+        .map((e) => CustomField.fromJson(e as Map<String, dynamic>))
+        .toList();
+    fields.sort((a, b) => a.order.compareTo(b.order));
+    return fields;
+  }
+
+  Future<void> createCustomField({
+    required String name,
+    required CustomFieldType type,
+    List<String> options = const [],
+  }) async {
+    final response = await post(
+      '/v1/manager/customfields',
+      body: {
+        'name': name,
+        'type': type.serverValue,
+        if (options.isNotEmpty) 'options': options,
+      },
+    );
+
+    if (response?.statusCode != 200 && response?.statusCode != 201) {
+      try {
+        throw LovatAPIException(jsonDecode(response!.body)['displayError']);
+      } on LovatAPIException {
+        rethrow;
+      } catch (_) {
+        throw Exception('Failed to create custom field');
+      }
+    }
+  }
+
+  Future<void> updateCustomField(
+    String uuid, {
+    String? name,
+    List<String>? options,
+  }) async {
+    final response = await put(
+      '/v1/manager/customfields/$uuid',
+      body: {
+        if (name != null) 'name': name,
+        if (options != null) 'options': options,
+      },
+    );
+
+    if (response?.statusCode != 200) {
+      try {
+        throw LovatAPIException(jsonDecode(response!.body)['displayError']);
+      } on LovatAPIException {
+        rethrow;
+      } catch (_) {
+        throw Exception('Failed to update custom field');
+      }
+    }
+  }
+
+  Future<void> archiveCustomField(String uuid) async {
+    final response = await post('/v1/manager/customfields/$uuid/archive');
+
+    if (response?.statusCode != 200) {
+      try {
+        throw LovatAPIException(jsonDecode(response!.body)['displayError']);
+      } on LovatAPIException {
+        rethrow;
+      } catch (_) {
+        throw Exception('Failed to archive custom field');
+      }
+    }
+  }
+
+  Future<void> unarchiveCustomField(String uuid) async {
+    final response = await post('/v1/manager/customfields/$uuid/unarchive');
+
+    if (response?.statusCode != 200) {
+      try {
+        throw LovatAPIException(jsonDecode(response!.body)['displayError']);
+      } on LovatAPIException {
+        rethrow;
+      } catch (_) {
+        throw Exception('Failed to unarchive custom field');
+      }
+    }
+  }
+
+  Future<void> reorderCustomFields(List<String> orderedUuids) async {
+    final response = await put(
+      '/v1/manager/customfields/order',
+      body: {
+        'fieldUuids': orderedUuids,
+      },
+    );
+
+    if (response?.statusCode != 200) {
+      try {
+        throw LovatAPIException(jsonDecode(response!.body)['displayError']);
+      } on LovatAPIException {
+        rethrow;
+      } catch (_) {
+        throw Exception('Failed to reorder custom fields');
+      }
+    }
+  }
+}
+
+/// Cached custom field definitions (including archived fields), refreshed by
+/// [getCustomFieldDefinitions].
+List<CustomField>? cachedCustomFields;
+
+/// The team's custom field definitions, including archived fields, fetched
+/// from the server the first time (or when [force] is true) and cached in
+/// [cachedCustomFields] afterwards.
+Future<List<CustomField>> getCustomFieldDefinitions({
+  bool force = false,
+}) async {
+  if (!force && cachedCustomFields != null) {
+    return cachedCustomFields!;
+  }
+
+  final fields = await lovatAPI.getCustomFields(includeArchived: true);
+  cachedCustomFields = fields;
+  return fields;
+}

--- a/lib/reusable/lovat_api/get_alliance_analysis.dart
+++ b/lib/reusable/lovat_api/get_alliance_analysis.dart
@@ -22,8 +22,9 @@ class AllianceTeam {
   RobotRoles? get robotRole => role == null ? null : RobotRoles.values[role!];
 
   factory AllianceTeam.fromJson(Map<String, dynamic> json) {
+    final teamValue = json['team'];
     return AllianceTeam(
-      team: json['team'] as int,
+      team: teamValue is int ? teamValue : int.parse(teamValue.toString()),
       role: json['role'] as int?,
       averagePoints: (json['averagePoints'] as num?)?.toDouble(),
       paths: (json['paths'] as List<dynamic>? ?? [])
@@ -49,20 +50,24 @@ class AllianceAnalysis {
   final List<num?> l1StartTime;
   final List<num?> l2StartTime;
   final List<num?> l3StartTime;
-  final num totalFuelOutputted;
-  final num totalBallThroughput;
+  final num? totalFuelOutputted;
+  final num? totalBallThroughput;
 
   factory AllianceAnalysis.fromJson(Map<String, dynamic> json) {
+    // The server omits/nulls these fields for alliances with too little data
+    // (e.g. a team with fewer than two recorded matches). Parse defensively so
+    // one weak alliance doesn't crash the whole Match Predictor / Alliance page;
+    // consumers already render "Not enough data" / "--" for empty/null values.
     return AllianceAnalysis(
-      teams: (json['teams'] as List<dynamic>)
+      teams: (json['teams'] as List<dynamic>? ?? const [])
           .map((e) => AllianceTeam.fromJson(e as Map<String, dynamic>))
           .toList(),
       totalPoints: (json['totalPoints'] as num?)?.toDouble(),
-      l1StartTime: (json['l1StartTime'] as List<dynamic>).cast<num?>(),
-      l2StartTime: (json['l2StartTime'] as List<dynamic>).cast<num?>(),
-      l3StartTime: (json['l3StartTime'] as List<dynamic>).cast<num?>(),
-      totalFuelOutputted: json['totalFuelOutputted'] as num,
-      totalBallThroughput: json['totalBallThroughput'] as num,
+      l1StartTime: (json['l1StartTime'] as List<dynamic>? ?? const []).cast<num?>(),
+      l2StartTime: (json['l2StartTime'] as List<dynamic>? ?? const []).cast<num?>(),
+      l3StartTime: (json['l3StartTime'] as List<dynamic>? ?? const []).cast<num?>(),
+      totalFuelOutputted: json['totalFuelOutputted'] as num?,
+      totalBallThroughput: json['totalBallThroughput'] as num?,
     );
   }
 }

--- a/lib/reusable/lovat_api/get_scout_report_analysis.dart
+++ b/lib/reusable/lovat_api/get_scout_report_analysis.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:scouting_dashboard_app/pages/raw_scout_report.dart';
 import 'package:scouting_dashboard_app/reusable/lovat_api/lovat_api.dart';
+import 'package:scouting_dashboard_app/reusable/models/custom_field_answer.dart';
 import 'package:scouting_dashboard_app/reusable/models/robot_roles.dart';
 import 'package:scouting_dashboard_app/reusable/team_auto_paths.dart';
 
@@ -47,6 +48,7 @@ class SingleScoutReportAnalysis {
     required this.autoScore,
     this.notes,
     this.robotBrokeDescription,
+    this.customFieldAnswers = const [],
   });
 
   final int totalPoints;
@@ -71,6 +73,7 @@ class SingleScoutReportAnalysis {
   final num autoScore;
   final String? notes;
   final String? robotBrokeDescription;
+  final List<CustomFieldAnswerDisplay> customFieldAnswers;
 
   factory SingleScoutReportAnalysis.fromJson(Map<String, dynamic> json) {
     return SingleScoutReportAnalysis(
@@ -102,6 +105,8 @@ class SingleScoutReportAnalysis {
           json["volleys"] != 0 ? json["totalBallsFed"] / json["volleys"] : 0,
       notes: (json['note'] as String).isEmpty ? null : json['note'],
       robotBrokeDescription: json['robotBrokeDescription'],
+      customFieldAnswers:
+          CustomFieldAnswerDisplay.listFromJson(json['customFieldAnswers']),
     );
   }
 }

--- a/lib/reusable/lovat_api/get_scout_report_analysis.dart
+++ b/lib/reusable/lovat_api/get_scout_report_analysis.dart
@@ -49,6 +49,9 @@ class SingleScoutReportAnalysis {
     this.notes,
     this.robotBrokeDescription,
     this.customFieldAnswers = const [],
+    this.canModify = false,
+    this.customFieldsAreOwnTeam = true,
+    this.customFieldsSourceTeam,
   });
 
   final int totalPoints;
@@ -74,6 +77,18 @@ class SingleScoutReportAnalysis {
   final String? notes;
   final String? robotBrokeDescription;
   final List<CustomFieldAnswerDisplay> customFieldAnswers;
+
+  /// Whether the viewer (a scouting lead of the report's team) may edit this
+  /// report's text custom field answers.
+  final bool canModify;
+
+  /// Whether the custom questions belong to the viewer's own team. False when
+  /// viewing another team's shared report, so the section isn't mislabeled
+  /// "Asked by your team".
+  final bool customFieldsAreOwnTeam;
+
+  /// The team whose custom questions these answers belong to.
+  final int? customFieldsSourceTeam;
 
   factory SingleScoutReportAnalysis.fromJson(Map<String, dynamic> json) {
     return SingleScoutReportAnalysis(
@@ -107,6 +122,9 @@ class SingleScoutReportAnalysis {
       robotBrokeDescription: json['robotBrokeDescription'],
       customFieldAnswers:
           CustomFieldAnswerDisplay.listFromJson(json['customFieldAnswers']),
+      canModify: json['canModify'] == true,
+      customFieldsAreOwnTeam: json['customFieldsAreOwnTeam'] != false,
+      customFieldsSourceTeam: (json['customFieldsSourceTeam'] as num?)?.toInt(),
     );
   }
 }

--- a/lib/reusable/lovat_api/get_scouter_overviews.dart
+++ b/lib/reusable/lovat_api/get_scouter_overviews.dart
@@ -10,7 +10,9 @@ extension ScouterOverviewsQuery on LovatAPI {
       {bool archivedScouters = false}) {
     const path = '/v1/manager/scouterspage';
     return CachedQuery(
-      queryKey: ['scouterOverviews', archivedScouters],
+      // Include the current tournament (resolved inside queryFn) in the cache
+      // key so switching tournaments doesn't serve the previous one's scouters.
+      queryKey: ['scouterOverviews', archivedScouters, Tournament.currentSync?.key],
       label: 'scouter overviews',
       queryFn: () async {
         final tournament = await Tournament.getCurrent();

--- a/lib/reusable/lovat_api/picklists/get_picklist_analysis.dart
+++ b/lib/reusable/lovat_api/picklists/get_picklist_analysis.dart
@@ -8,6 +8,30 @@ import 'package:scouting_dashboard_app/reusable/flag_models.dart';
 import 'package:scouting_dashboard_app/reusable/lovat_api/lovat_api.dart';
 import 'package:scouting_dashboard_app/reusable/stale_refresh_builder.dart';
 
+bool _isCustomWeight(PicklistWeight weight) =>
+    weight.isCustom || weight.path.startsWith('cf_');
+
+/// Serializes [weights] for the picklist analysis endpoint: built-in weights
+/// as individual query params, custom field weights combined into a single
+/// `customWeights` JSON object param (omitted entirely when there are no
+/// non-zero custom weights).
+Map<String, String> _weightsQuery(List<PicklistWeight> weights) {
+  final customWeights = Map.fromEntries(
+    weights
+        .where((e) => _isCustomWeight(e) && e.value != 0)
+        .map((e) => MapEntry(e.path, e.value)),
+  );
+
+  return {
+    ...Map.fromEntries(
+      weights
+          .where((e) => !_isCustomWeight(e))
+          .map((e) => MapEntry(e.path, e.value.toString())),
+    ),
+    if (customWeights.isNotEmpty) 'customWeights': jsonEncode(customWeights),
+  };
+}
+
 class PicklistBreakdownEntry {
   const PicklistBreakdownEntry({
     required this.type,
@@ -79,9 +103,7 @@ extension PicklistAnalysisQuery on LovatAPI {
           query: {
             if (tournament != null) 'tournamentKey': tournament.key,
             'flags': jsonEncode(flags),
-            ...Map.fromEntries(
-              weights.map((e) => MapEntry(e.path, e.value.toString())).toList(),
-            ),
+            ..._weightsQuery(weights),
           },
         );
 
@@ -104,9 +126,7 @@ extension PicklistAnalysisQuery on LovatAPI {
           query: {
             if (tournament != null) 'tournamentKey': tournament.key,
             'flags': jsonEncode(flags),
-            ...Map.fromEntries(
-              weights.map((e) => MapEntry(e.path, e.value.toString())).toList(),
-            ),
+            ..._weightsQuery(weights),
           },
           parser: (json) {
             final map = json as Map<String, dynamic>;
@@ -124,9 +144,7 @@ extension PicklistAnalysisQuery on LovatAPI {
           query: {
             if (tournament != null) 'tournamentKey': tournament.key,
             'flags': jsonEncode(flags),
-            ...Map.fromEntries(
-              weights.map((e) => MapEntry(e.path, e.value.toString())).toList(),
-            ),
+            ..._weightsQuery(weights),
           },
         );
       },

--- a/lib/reusable/lovat_api/picklists/get_picklist_analysis.dart
+++ b/lib/reusable/lovat_api/picklists/get_picklist_analysis.dart
@@ -91,6 +91,10 @@ extension PicklistAnalysisQuery on LovatAPI {
     return CachedQuery(
       queryKey: [
         'picklistAnalysis',
+        // The analysis is scoped to the current tournament (resolved inside
+        // queryFn), so it must be part of the in-memory cache key — otherwise
+        // switching tournaments serves the previous tournament's cached result.
+        Tournament.currentSync?.key,
         flags,
         weights.map((e) => [e.path, e.value]).toList()
       ],

--- a/lib/reusable/lovat_api/picklists/shared/get_shared_picklist_by_id.dart
+++ b/lib/reusable/lovat_api/picklists/shared/get_shared_picklist_by_id.dart
@@ -1,15 +1,24 @@
 import 'package:flutter/foundation.dart';
 import 'package:scouting_dashboard_app/pages/picklist/picklist_models.dart';
+import 'package:scouting_dashboard_app/reusable/lovat_api/custom_fields.dart';
 import 'package:scouting_dashboard_app/reusable/lovat_api/lovat_api.dart';
 
 extension GetSharedPicklistById on LovatAPI {
   ConfiguredPicklist? getCachedSharedPicklistById(String id) {
     final response = getCachedResponse('/v1/manager/picklists/$id');
     if (response == null) return null;
-    return ConfiguredPicklist.fromServerJSON(response.body);
+
+    final fields = cachedCustomFields;
+
+    return ConfiguredPicklist.fromServerJSON(
+      response.body,
+      allWeights: fields == null ? null : allPicklistWeightsFromFields(fields),
+    );
   }
 
   Future<ConfiguredPicklist> getSharedPicklistById(String id) async {
+    final allWeights = await getAllPicklistWeights();
+
     final response = await get('/v1/manager/picklists/$id');
 
     if (response?.statusCode != 200) {
@@ -17,6 +26,9 @@ extension GetSharedPicklistById on LovatAPI {
       throw Exception('Failed to get shared picklist');
     }
 
-    return ConfiguredPicklist.fromServerJSON(response!.body);
+    return ConfiguredPicklist.fromServerJSON(
+      response!.body,
+      allWeights: allWeights,
+    );
   }
 }

--- a/lib/reusable/lovat_api/picklists/shared/share_picklist.dart
+++ b/lib/reusable/lovat_api/picklists/shared/share_picklist.dart
@@ -6,14 +6,25 @@ extension SharePicklist on LovatAPI {
   Future<void> sharePicklist(
     ConfiguredPicklist picklist,
   ) async {
+    bool isCustom(PicklistWeight weight) =>
+        weight.isCustom || weight.path.startsWith('cf_');
+
+    final customWeights = picklist.weights.where(isCustom).toList();
+
     // POST /v1/manager/picklists
     final response = await post(
       '/v1/manager/picklists',
       body: {
         'name': picklist.title,
         ...Map.fromEntries(
-          picklist.weights.map((e) => MapEntry(e.path, e.value)),
+          picklist.weights
+              .where((e) => !isCustom(e))
+              .map((e) => MapEntry(e.path, e.value)),
         ),
+        if (customWeights.isNotEmpty)
+          'customFieldWeights': Map.fromEntries(
+            customWeights.map((e) => MapEntry(e.path, e.value)),
+          ),
       },
     );
 

--- a/lib/reusable/lovat_api/team_lookup/get_breakdown_metrics.dart
+++ b/lib/reusable/lovat_api/team_lookup/get_breakdown_metrics.dart
@@ -5,19 +5,30 @@ import 'package:scouting_dashboard_app/reusable/lovat_api/lovat_api.dart';
 import 'package:scouting_dashboard_app/reusable/stale_refresh_builder.dart';
 
 class BreakdownMetrics {
-  const BreakdownMetrics(this._values);
+  const BreakdownMetrics(this._values, {this.customFields = const []});
 
   final Map<String, Map<String, double>> _values;
 
+  /// The viewing team's custom fields included inline in the response, whose
+  /// values are the flat `cf_<uuid>` entries of the breakdown map.
+  final List<CustomFieldBreakdownInfo> customFields;
+
   factory BreakdownMetrics.fromJson(Map<String, dynamic> json) {
     return BreakdownMetrics(
-      json.map((breakdownPath, segments) => MapEntry(
-            breakdownPath,
-            (segments as Map<String, dynamic>).map(
-              (segmentPath, value) =>
-                  MapEntry(segmentPath, (value as num?)?.toDouble() ?? 0),
-            ),
-          )),
+      Map.fromEntries(
+        json.entries
+            .where((entry) =>
+                entry.key != 'customFields' &&
+                entry.value is Map<String, dynamic>)
+            .map((entry) => MapEntry(
+                  entry.key,
+                  (entry.value as Map<String, dynamic>).map(
+                    (segmentPath, value) =>
+                        MapEntry(segmentPath, (value as num?)?.toDouble() ?? 0),
+                  ),
+                )),
+      ),
+      customFields: CustomFieldBreakdownInfo.listFromJson(json['customFields']),
     );
   }
 
@@ -28,6 +39,56 @@ class BreakdownMetrics {
 
   bool isEmpty(String breakdownPath) =>
       _values[breakdownPath] == null || _values[breakdownPath]!.isEmpty;
+}
+
+/// Metadata about one of the viewing team's custom fields, included inline in
+/// the breakdown metrics response as an entry of the `customFields` array
+/// (`{uuid, metricKey, name, order, type, options}`).
+class CustomFieldBreakdownInfo {
+  const CustomFieldBreakdownInfo({
+    required this.metricKey,
+    required this.name,
+    this.order = 0,
+    this.options = const [],
+  });
+
+  final String metricKey;
+  final String name;
+  final int order;
+  final List<String> options;
+
+  /// Parses a single metadata entry, returning null for malformed entries.
+  static CustomFieldBreakdownInfo? tryFromJson(dynamic json) {
+    if (json is! Map<String, dynamic>) return null;
+
+    final metricKey = json['metricKey'];
+    final name = json['name'];
+
+    if (metricKey is! String || name is! String) return null;
+
+    final order = json['order'];
+    final options = json['options'];
+
+    return CustomFieldBreakdownInfo(
+      metricKey: metricKey,
+      name: name,
+      order: order is num ? order.toInt() : 0,
+      options:
+          options is List ? options.whereType<String>().toList() : const [],
+    );
+  }
+
+  /// Parses the `customFields` metadata array from a breakdown metrics
+  /// response, tolerating a missing or malformed array and skipping bad
+  /// entries. Results are sorted by field order.
+  static List<CustomFieldBreakdownInfo> listFromJson(dynamic json) {
+    if (json is! List) return [];
+
+    final fields =
+        json.map(tryFromJson).whereType<CustomFieldBreakdownInfo>().toList();
+    fields.sort((a, b) => a.order.compareTo(b.order));
+    return fields;
+  }
 }
 
 extension BreakdownMetricsQuery on LovatAPI {

--- a/lib/reusable/lovat_api/team_lookup/get_notes.dart
+++ b/lib/reusable/lovat_api/team_lookup/get_notes.dart
@@ -55,11 +55,17 @@ class CustomTextAnswer {
   final String name;
   final String value;
 
-  factory CustomTextAnswer.fromJson(Map<String, dynamic> json) =>
-      CustomTextAnswer(
-        name: json['name'] as String,
-        value: json['value'] as String,
-      );
+  /// Tolerant parse: returns null for a malformed or blank text answer so one
+  /// bad entry can't throw and take down the entire Notes tab. Also skips
+  /// whitespace-only values, matching the raw-report surface which hides them.
+  static CustomTextAnswer? tryFromJson(Map<String, dynamic> json) {
+    final name = json['name'];
+    final value = json['value'];
+    if (name is! String || value is! String || value.trim().isEmpty) {
+      return null;
+    }
+    return CustomTextAnswer(name: name, value: value);
+  }
 }
 
 class Note {
@@ -120,7 +126,8 @@ class Note {
       if (json['customTextAnswers'] is List)
         ...(json['customTextAnswers'] as List)
             .whereType<Map<String, dynamic>>()
-            .map(CustomTextAnswer.fromJson),
+            .map(CustomTextAnswer.tryFromJson)
+            .whereType<CustomTextAnswer>(),
     ];
 
     final hasNote =

--- a/lib/reusable/lovat_api/team_lookup/get_notes.dart
+++ b/lib/reusable/lovat_api/team_lookup/get_notes.dart
@@ -67,15 +67,41 @@ class Note {
     required this.body,
     required this.matchIdentity,
     this.author,
+    this.sourceTeam,
     this.uuid,
+    this.teamNumber,
     this.type = NoteType.note,
     this.customTextAnswers = const [],
   });
 
+  Note copyWith({int? teamNumber}) => Note(
+        body: body,
+        matchIdentity: matchIdentity,
+        author: author,
+        sourceTeam: sourceTeam,
+        uuid: uuid,
+        teamNumber: teamNumber ?? this.teamNumber,
+        type: type,
+        customTextAnswers: customTextAnswers,
+      );
+
   final String body;
   final GameMatchIdentity matchIdentity;
+
+  /// The scout's name, only present for the viewer's own team. For other teams
+  /// it's null and [sourceTeam] is used for anonymized attribution instead.
   final String? author;
+
+  /// The team whose scout wrote the report, used to attribute other teams'
+  /// notes as "Scouter from <team>".
+  final int? sourceTeam;
+
+  /// The scout report's uuid, used to open its raw data page.
   final String? uuid;
+
+  /// The team being looked up (injected by the tab), used when navigating to
+  /// the raw report page.
+  final int? teamNumber;
   final NoteType type;
 
   /// Text custom field answers from the same report, in field order. Only set
@@ -97,7 +123,8 @@ class Note {
             .map(CustomTextAnswer.fromJson),
     ];
 
-    final hasNote = json["notes"] is String && (json["notes"] as String).isNotEmpty;
+    final hasNote =
+        json["notes"] is String && (json["notes"] as String).isNotEmpty;
 
     return [
       // One card per report: the written note (if any) together with that
@@ -109,6 +136,7 @@ class Note {
           matchIdentity: GameMatchIdentity.fromLongKey(json['match'],
               tournamentName: json['tournamentName']),
           author: json['scouterName'],
+          sourceTeam: (json['sourceTeam'] as num?)?.toInt(),
           uuid: json['uuid'],
           customTextAnswers: customTextAnswers,
         ),
@@ -120,6 +148,7 @@ class Note {
             matchIdentity: GameMatchIdentity.fromLongKey(json['match'],
                 tournamentName: json['tournamentName']),
             author: json['scouterName'],
+            sourceTeam: (json['sourceTeam'] as num?)?.toInt(),
             uuid: json['uuid'],
             type: NoteType.breakDescription),
     ];

--- a/lib/reusable/lovat_api/team_lookup/get_notes.dart
+++ b/lib/reusable/lovat_api/team_lookup/get_notes.dart
@@ -47,6 +47,21 @@ extension NotesQuery on LovatAPI {
 
 enum NoteType { note, breakDescription }
 
+/// A free-form ("Text") custom field answer attached to a scout report, shown
+/// below the report's note on the same card.
+class CustomTextAnswer {
+  const CustomTextAnswer({required this.name, required this.value});
+
+  final String name;
+  final String value;
+
+  factory CustomTextAnswer.fromJson(Map<String, dynamic> json) =>
+      CustomTextAnswer(
+        name: json['name'] as String,
+        value: json['value'] as String,
+      );
+}
+
 class Note {
   const Note({
     required this.body,
@@ -54,6 +69,7 @@ class Note {
     this.author,
     this.uuid,
     this.type = NoteType.note,
+    this.customTextAnswers = const [],
   });
 
   final String body;
@@ -61,6 +77,10 @@ class Note {
   final String? author;
   final String? uuid;
   final NoteType type;
+
+  /// Text custom field answers from the same report, in field order. Only set
+  /// on [NoteType.note] cards.
+  final List<CustomTextAnswer> customTextAnswers;
 
   factory Note.fromJson(Map<String, dynamic> json) => Note(
         body: json['notes'],
@@ -70,16 +90,27 @@ class Note {
         uuid: json['uuid'],
       );
   static List<Note> fromJoinedMap(Map<String, dynamic> json) {
+    final customTextAnswers = <CustomTextAnswer>[
+      if (json['customTextAnswers'] is List)
+        ...(json['customTextAnswers'] as List)
+            .whereType<Map<String, dynamic>>()
+            .map(CustomTextAnswer.fromJson),
+    ];
+
+    final hasNote = json["notes"] is String && (json["notes"] as String).isNotEmpty;
+
     return [
-      if (json.containsKey("notes") &&
-          json["notes"].runtimeType == String &&
-          (json["notes"] as String).isNotEmpty)
+      // One card per report: the written note (if any) together with that
+      // report's text custom answers. Emitted when either is present, so a
+      // report with only a custom answer still gets a card.
+      if (hasNote || customTextAnswers.isNotEmpty)
         Note(
-          body: json['notes'],
+          body: hasNote ? json['notes'] as String : "",
           matchIdentity: GameMatchIdentity.fromLongKey(json['match'],
               tournamentName: json['tournamentName']),
           author: json['scouterName'],
           uuid: json['uuid'],
+          customTextAnswers: customTextAnswers,
         ),
       if (json.containsKey("robotBrokeDescription") &&
           json["robotBrokeDescription"].runtimeType == String &&

--- a/lib/reusable/models/custom_field_answer.dart
+++ b/lib/reusable/models/custom_field_answer.dart
@@ -1,0 +1,112 @@
+import 'package:scouting_dashboard_app/reusable/lovat_api/custom_fields.dart';
+
+/// A custom field answer as returned in raw scout report responses.
+class CustomFieldAnswerDisplay {
+  const CustomFieldAnswerDisplay({
+    required this.fieldUuid,
+    required this.name,
+    required this.type,
+    this.options = const [],
+    this.order = 0,
+    this.archived = false,
+    this.textValue,
+    this.numberValue,
+    this.selections = const [],
+  });
+
+  final String fieldUuid;
+  final String name;
+  final CustomFieldType type;
+  final List<String> options;
+  final int order;
+  final bool archived;
+  final String? textValue;
+  final double? numberValue;
+  final List<String> selections;
+
+  /// The value to display for this answer, depending on [type]:
+  /// NUMBER -> [numberValue], TEXT -> [textValue], SINGLE_SELECT -> the first
+  /// selection (or null), MULTI_SELECT -> [selections].
+  dynamic get displayValue {
+    switch (type) {
+      case CustomFieldType.text:
+        return textValue;
+      case CustomFieldType.number:
+        return numberValue;
+      case CustomFieldType.singleSelect:
+        return selections.isNotEmpty ? selections.first : null;
+      case CustomFieldType.multiSelect:
+        return selections;
+    }
+  }
+
+  bool get hasDisplayableValue {
+    switch (type) {
+      case CustomFieldType.text:
+        return textValue != null && textValue!.trim().isNotEmpty;
+      case CustomFieldType.number:
+        return numberValue != null;
+      case CustomFieldType.singleSelect:
+      case CustomFieldType.multiSelect:
+        return selections.isNotEmpty;
+    }
+  }
+
+  /// Parses a single raw-report entry, returning null for entries that are
+  /// malformed or have no displayable value.
+  static CustomFieldAnswerDisplay? tryFromJson(dynamic json) {
+    if (json is! Map<String, dynamic>) return null;
+
+    final fieldUuid = json['fieldUuid'];
+    final name = json['name'];
+    final serverType = json['type'];
+
+    if (fieldUuid is! String || name is! String || serverType is! String) {
+      return null;
+    }
+
+    final CustomFieldType type;
+    try {
+      type = CustomFieldTypeExtension.fromServerValue(serverType);
+    } catch (_) {
+      return null;
+    }
+
+    final options = json['options'];
+    final order = json['order'];
+    final textValue = json['textValue'];
+    final numberValue = json['numberValue'];
+    final selections = json['selections'];
+
+    final answer = CustomFieldAnswerDisplay(
+      fieldUuid: fieldUuid,
+      name: name,
+      type: type,
+      options:
+          options is List ? options.whereType<String>().toList() : const [],
+      order: order is num ? order.toInt() : 0,
+      archived: json['archived'] == true,
+      textValue: textValue is String ? textValue : null,
+      numberValue: numberValue is num ? numberValue.toDouble() : null,
+      selections: selections is List
+          ? selections.whereType<String>().toList()
+          : const [],
+    );
+
+    if (!answer.hasDisplayableValue) return null;
+
+    return answer;
+  }
+
+  /// Parses the `customFieldAnswers` array from a raw-report response,
+  /// tolerating a missing or malformed array and skipping entries with no
+  /// displayable value. Results are sorted by field order.
+  static List<CustomFieldAnswerDisplay> listFromJson(dynamic json) {
+    if (json is! List) return [];
+
+    final answers =
+        json.map(tryFromJson).whereType<CustomFieldAnswerDisplay>().toList();
+    answers.sort((a, b) => a.order.compareTo(b.order));
+    return answers;
+  }
+}

--- a/lib/reusable/models/custom_field_answer.dart
+++ b/lib/reusable/models/custom_field_answer.dart
@@ -3,6 +3,7 @@ import 'package:scouting_dashboard_app/reusable/lovat_api/custom_fields.dart';
 /// A custom field answer as returned in raw scout report responses.
 class CustomFieldAnswerDisplay {
   const CustomFieldAnswerDisplay({
+    this.uuid,
     required this.fieldUuid,
     required this.name,
     required this.type,
@@ -14,6 +15,9 @@ class CustomFieldAnswerDisplay {
     this.selections = const [],
   });
 
+  /// The answer's own uuid, used to edit it. Null on responses from servers
+  /// that predate editable answers.
+  final String? uuid;
   final String fieldUuid;
   final String name;
   final CustomFieldType type;
@@ -79,6 +83,7 @@ class CustomFieldAnswerDisplay {
     final selections = json['selections'];
 
     final answer = CustomFieldAnswerDisplay(
+      uuid: json['uuid'] is String ? json['uuid'] : null,
       fieldUuid: fieldUuid,
       name: name,
       type: type,

--- a/lib/reusable/navigation_drawer.dart
+++ b/lib/reusable/navigation_drawer.dart
@@ -129,6 +129,16 @@ class _GlobalNavigationDrawerState extends State<GlobalNavigationDrawer> {
                       ModalRoute.of(context)?.settings.name == "/scouters",
                   icon: Icons.supervised_user_circle,
                 ),
+                DrawerDestination(
+                  label: "Custom Fields",
+                  onTap: () {
+                    Navigator.pushNamedAndRemoveUntil(
+                        context, "/custom_fields", (route) => false);
+                  },
+                  isSelected:
+                      ModalRoute.of(context)?.settings.name == "/custom_fields",
+                  icon: Icons.dynamic_form,
+                ),
               ],
               if (selectedTournament != null) ...[
                 DrawerDestination(

--- a/lib/reusable/stale_refresh_builder.dart
+++ b/lib/reusable/stale_refresh_builder.dart
@@ -110,11 +110,13 @@ class _StaleRefreshBuilderState<T> extends State<StaleRefreshBuilder<T>> {
   }
 
   bool _keyEquals(List<dynamic> a, List<dynamic> b) {
-    if (a.length != b.length) return false;
-    for (var i = 0; i < a.length; i++) {
-      if (a[i] != b[i]) return false;
-    }
-    return true;
+    // Compare by the same serialization QueryCache uses for its keys. A shallow
+    // element-wise `!=` compared nested List/Map elements by identity, so keys
+    // containing nested collections (e.g. picklistAnalysis' flags/weights, which
+    // are rebuilt into fresh instances every build) always looked "changed" —
+    // causing needless refetch churn and, worse, discarding in-flight results
+    // whose key instance no longer matched _activeKey.
+    return QueryCache._keyToString(a) == QueryCache._keyToString(b);
   }
 
   Future<void> _fetch() async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 26.0.6+34
+version: 26.0.7+35
 
 environment:
   sdk: ">=3.0.0 <=3.27.3"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 26.0.4+33
+version: 26.0.6+34
 
 environment:
   sdk: ">=3.0.0 <=3.27.3"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 26.0.7+35
+version: 26.0.8+36
 
 environment:
   sdk: ">=3.0.0 <=3.27.3"


### PR DESCRIPTION
Adds custom fields to the dashboard: scouting leads configure custom post-match questions, and their answers appear throughout analysis clearly marked as custom.

## What's here
- **New "Custom Fields" page** off the nav drawer (scouting leads only): list, create/edit with an options editor, drag-to-reorder, archive/unarchive. Type is immutable after creation (matching the server contract).
- **`custom_fields.dart` API extension** + in-memory definitions cache.
- **Raw report**: an "Asked by your team" section rendering each answer by type.
- **Team Lookup**: number answers as an "Asked by your team" category with per-match detail graphs; select answers as breakdown distributions.
- **Picklists**: number fields become sliders, resilient to archived/unknown fields; custom weights sent via a single `customWeights` param and persisted on shared picklists.
- **`CustomFieldIndicator`** — a shared "Custom" chip on picklist/breakdown surfaces; grouping headers mark the rest. Never two markers on one surface.

Every custom section is hidden when empty (no blank scaffolding).

## Testing
Validated live on an iOS simulator against a local server: created a field through the real UI, and confirmed the category average, detail sparkline, and breakdown distributions all render with the correct seeded values, plus cross-team isolation (a 9470 viewer sees none of 8033's custom data). `flutter analyze` clean (no new issues).


---

**Related PRs** — this feature spans four repos:
- lovat-server: https://github.com/HighlanderRobotics/lovat-server/pull/54
- lovat-collection: https://github.com/HighlanderRobotics/lovat-collection/pull/85
- Lovat Dashboard: https://github.com/HighlanderRobotics/scouting_dashboard_app/pull/130
- lovat-learn: https://github.com/MangoSwirl/lovat-learn/pull/15
